### PR TITLE
Make formatting consistent. Remove unused usings.

### DIFF
--- a/Core/Constants.cs
+++ b/Core/Constants.cs
@@ -1,147 +1,143 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
-
 namespace MinishRandomizer.Core
 {
-	public enum RegionVersion
-	{
-		EU,
-		JP,
-		US,
-		None
-	}
+    public enum RegionVersion
+    {
+        EU,
+        JP,
+        US,
+        None
+    }
 
-	public struct HeaderData
-	{
-		public int MapHeaderBase;
-		// Name on this is gonna have to change sometime
-		public int AreaMetadataBase;
+    public struct HeaderData
+    {
+        public int MapHeaderBase;
+        // Name on this is gonna have to change sometime
+        public int AreaMetadataBase;
 
-		//added for now, change names to whatever you want
-		public int tileOffset;
-		public int paletteSetTableLoc;
-		public int chunk0TableLoc;
-		public int area1Chunk0TableLoc;
-		public int chunk1TableLoc;
-		public int chunk2TableLoc;
-		public int swapBase;
-		public int paletteChangeBase;
-		public int area1SwapBase;
-		public int globalTileSetTableLoc;
-		public int gfxSourceBase;
-		public int globalMetaTileSetTableLoc;
-		public int globalTileDataTableLoc;
+        //added for now, change names to whatever you want
+        public int tileOffset;
+        public int paletteSetTableLoc;
+        public int chunk0TableLoc;
+        public int area1Chunk0TableLoc;
+        public int chunk1TableLoc;
+        public int chunk2TableLoc;
+        public int swapBase;
+        public int paletteChangeBase;
+        public int area1SwapBase;
+        public int globalTileSetTableLoc;
+        public int gfxSourceBase;
+        public int globalMetaTileSetTableLoc;
+        public int globalTileDataTableLoc;
 
-		public HeaderData( int map, int area, int tileOffset, int paletteSetTableLoc, int c0TableLoc, int a1C0TableLoc, int c1TableLoc, int c2TableLoc, int swapBase, int paletteChangeBase, int area1SwapBase, int globalTileSetTableLoc, int gfxSourceBase, int globalMetaTileSetTableLoc, int globalTileDataTableLoc )
-		{
-			this.MapHeaderBase = map;
-			this.AreaMetadataBase = area;
-			this.tileOffset = tileOffset;
-			this.paletteSetTableLoc = paletteSetTableLoc;
-			this.chunk0TableLoc = c0TableLoc; //looks like each next chunkTable is a 0x16 further (eu and us), not adding because of possible jp
-			this.area1Chunk0TableLoc = a1C0TableLoc;
-			this.chunk1TableLoc = c1TableLoc; //c0+ 0x16
-			this.chunk2TableLoc = c2TableLoc; //c0+ 0x32
-			this.swapBase = swapBase;
-			this.paletteChangeBase = paletteChangeBase;
-			this.area1SwapBase = area1SwapBase; //above -0x140?
-			this.globalTileSetTableLoc = globalTileSetTableLoc;
-			this.gfxSourceBase = gfxSourceBase;
-			this.globalMetaTileSetTableLoc = globalMetaTileSetTableLoc;
-			this.globalTileDataTableLoc = globalTileDataTableLoc;
-		}
-	}
+        public HeaderData(int map, int area, int tileOffset, int paletteSetTableLoc, int c0TableLoc, int a1C0TableLoc, int c1TableLoc, int c2TableLoc, int swapBase, int paletteChangeBase, int area1SwapBase, int globalTileSetTableLoc, int gfxSourceBase, int globalMetaTileSetTableLoc, int globalTileDataTableLoc)
+        {
+            this.MapHeaderBase = map;
+            this.AreaMetadataBase = area;
+            this.tileOffset = tileOffset;
+            this.paletteSetTableLoc = paletteSetTableLoc;
+            this.chunk0TableLoc = c0TableLoc; //looks like each next chunkTable is a 0x16 further (eu and us), not adding because of possible jp
+            this.area1Chunk0TableLoc = a1C0TableLoc;
+            this.chunk1TableLoc = c1TableLoc; //c0+ 0x16
+            this.chunk2TableLoc = c2TableLoc; //c0+ 0x32
+            this.swapBase = swapBase;
+            this.paletteChangeBase = paletteChangeBase;
+            this.area1SwapBase = area1SwapBase; //above -0x140?
+            this.globalTileSetTableLoc = globalTileSetTableLoc;
+            this.gfxSourceBase = gfxSourceBase;
+            this.globalMetaTileSetTableLoc = globalMetaTileSetTableLoc;
+            this.globalTileDataTableLoc = globalTileDataTableLoc;
+        }
+    }
 
-	public enum TileEntityType
-	{
-		None = 0x00,
-		TestA = 0x01,
-		Chest = 0x02,
-		BigChest = 0x03,
-		TestB = 0x04,
-		TestC = 0x05,
-	}
+    public enum TileEntityType
+    {
+        None = 0x00,
+        TestA = 0x01,
+        Chest = 0x02,
+        BigChest = 0x03,
+        TestB = 0x04,
+        TestC = 0x05,
+    }
 
-	public enum KinstoneType
-	{
-		UnTyped,
+    public enum KinstoneType
+    {
+        UnTyped,
 
-		YellowTornadoProng = 0x65,
-		YellowTornadoSpike = 0x66,
-		YellowTornadoChaotic = 0x67,
-		//68 and 69 are repeats of above
+        YellowTornadoProng = 0x65,
+        YellowTornadoSpike = 0x66,
+        YellowTornadoChaotic = 0x67,
+        //68 and 69 are repeats of above
 
-		YellowTotemProng = 0x6A,
-		YellowTotemWave = 0x6B,
-		YellowTotemZigZag = 0x6C,
+        YellowTotemProng = 0x6A,
+        YellowTotemWave = 0x6B,
+        YellowTotemZigZag = 0x6C,
 
-		YellowCrown = 0x6D,
+        YellowCrown = 0x6D,
 
-		RedSpike = 0x6E,
-		RedCrack = 0x6F,
-		RedProng = 0x70,
+        RedSpike = 0x6E,
+        RedCrack = 0x6F,
+        RedProng = 0x70,
 
-		BlueL = 0x71,
-		BlueS = 0x72,
+        BlueL = 0x71,
+        BlueS = 0x72,
 
-		GreenSpike = 0x73,
-		GreenSquare = 0x74,
-		GreenSplit = 0x75,
-	}
+        GreenSpike = 0x73,
+        GreenSquare = 0x74,
+        GreenSplit = 0x75,
+    }
 
-	public enum ItemType
-	{
-		Untyped,
+    public enum ItemType
+    {
+        Untyped,
         SmithSword = 0x01,
         GreenSword = 0x02,
         RedSword = 0x03,
         BlueSword = 0x04,
-//      UnusedSword = 0x05,
+        //      UnusedSword = 0x05,
         FourSword = 0x06,
         Bombs = 0x07,
         RemoteBombs = 0x08,
-		Bow = 0x09,
+        Bow = 0x09,
         LightArrow = 0x0A,
         Boomerang = 0x0B,
-		MagicBoomerang = 0x0C,
+        MagicBoomerang = 0x0C,
         Shield = 0x0D,
         MirrorShield = 0x0E,
-		LanternOff = 0x0F,
-        
-		GustJar = 0x11,
-		PacciCane = 0x12,
-		MoleMitts = 0x13,
-		RocsCape = 0x14,
-		PegasusBoots = 0x15,
-		FireRod = 0x16,
-		Ocarina = 0x17,
+        LanternOff = 0x0F,
+
+        GustJar = 0x11,
+        PacciCane = 0x12,
+        MoleMitts = 0x13,
+        RocsCape = 0x14,
+        PegasusBoots = 0x15,
+        FireRod = 0x16,
+        Ocarina = 0x17,
         GreenOrb = 0x18,
         BlueOrb = 0x19,
         RedOrb = 0x1A,
         Trap = 0x1B,
-		Bottle1 = 0x1C,
-		Bottle2 = 0x1D,
-		Bottle3 = 0x1E,
-		Bottle4 = 0x1F,
-		BottleEmpty = 0x20,
-		BottleButter = 0x21,
-		BottleMilk = 0x22,
-		BottleHalfMilk = 0x23,
-		BottleRedPotion = 0x24,
-		BottleBluePotion = 0x25,
-		BottleWater = 0x26,
-		BottleMineralWater = 0x27,
-		BottleFairy = 0x28,
-		BottlePicolyteRed = 0x29,
-		BottlePicolyteOrange = 0x2A,
-		BottlePicolyteYellow = 0x2B,
-		BottlePiclolyteGreen = 0x2C,
-		BottlePicolyteBlue = 0x2D,
-		BottlePicolyteWhite = 0x2E,
-		BottleCharmNayru = 0x2F,
-		BottleCharmFarore = 0x30,
-		BottleCharmDin = 0x31,
+        Bottle1 = 0x1C,
+        Bottle2 = 0x1D,
+        Bottle3 = 0x1E,
+        Bottle4 = 0x1F,
+        BottleEmpty = 0x20,
+        BottleButter = 0x21,
+        BottleMilk = 0x22,
+        BottleHalfMilk = 0x23,
+        BottleRedPotion = 0x24,
+        BottleBluePotion = 0x25,
+        BottleWater = 0x26,
+        BottleMineralWater = 0x27,
+        BottleFairy = 0x28,
+        BottlePicolyteRed = 0x29,
+        BottlePicolyteOrange = 0x2A,
+        BottlePicolyteYellow = 0x2B,
+        BottlePiclolyteGreen = 0x2C,
+        BottlePicolyteBlue = 0x2D,
+        BottlePicolyteWhite = 0x2E,
+        BottleCharmNayru = 0x2F,
+        BottleCharmFarore = 0x30,
+        BottleCharmDin = 0x31,
 
 
         SmithSwordQuest = 0x34,
@@ -155,15 +151,15 @@ namespace MinishRandomizer.Core
         GraveyardKey = 0x3C,
         TingleTrophy = 0x3D,
         CarlovMedal = 0x3E,
-		ShellsX = 0x3F,
+        ShellsX = 0x3F,
         EarthElement = 0x40,
         FireElement = 0x41,
         WaterElement = 0x42,
         WindElement = 0x43,
         GripRing = 0x44,
-		PowerBracelets = 0x45,
-		Flippers = 0x46,
-		HyruleMap = 0x47,
+        PowerBracelets = 0x45,
+        Flippers = 0x46,
+        HyruleMap = 0x47,
         SpinAttack = 0x48,
         RollAttack = 0x49,
         DashAttack = 0x4A,
@@ -172,19 +168,19 @@ namespace MinishRandomizer.Core
         GreatSpin = 0x4D,
         DownThrust = 0x4E,
         PerilBeam = 0x4F,
-		DungeonMap = 0x50,
-		Compass = 0x51,
-		BigKey = 0x52,
-		SmallKey = 0x53,
-		Rupee1 = 0x54,
-		Rupee5 = 0x55,
-		Rupee20 = 0x56,
-		Rupee50 = 0x57,
-		Rupee100 = 0x58,
-		Rupee200 = 0x59,
+        DungeonMap = 0x50,
+        Compass = 0x51,
+        BigKey = 0x52,
+        SmallKey = 0x53,
+        Rupee1 = 0x54,
+        Rupee5 = 0x55,
+        Rupee20 = 0x56,
+        Rupee50 = 0x57,
+        Rupee100 = 0x58,
+        Rupee200 = 0x59,
 
         JabberNut = 0x5B,
-		KinstoneX = 0x5C,
+        KinstoneX = 0x5C,
         Bombs5 = 0x5D,
         Arrows5 = 0x5E,
         SmallHeart = 0x5F,
@@ -210,21 +206,21 @@ namespace MinishRandomizer.Core
         FastSpin = 0x73,
         FastSplit = 0x74,
         LongSpin = 0x75
-	}
+    }
 
-	public class Header
-	{
-		// Will fill out when relevant, only need EU for now
-		private readonly HeaderData[] headerTable = new HeaderData[]
-		{   //             MAP     , ENTITY?,	TILEOFFSET	PALETTESET	CHUNK0		CHUNK0AREA1	CHUNK1		CHUNK2		SWAP		PALETTECHANGE	AREA1SWAP	TILESET		GFXSOURCE	METATILE	TILEDATA
+    public class Header
+    {
+        // Will fill out when relevant, only need EU for now
+        private readonly HeaderData[] headerTable = new HeaderData[]
+        {   //             MAP     , ENTITY?,	TILEOFFSET	PALETTESET	CHUNK0		CHUNK0AREA1	CHUNK1		CHUNK2		SWAP		PALETTECHANGE	AREA1SWAP	TILESET		GFXSOURCE	METATILE	TILEDATA
             new HeaderData(0x11D95C, 0x0D4828,  0x5A23D0,   0xFED88,    0x107AEC,   0x1077AC,   0x107B02,   0x107B18,   0x107B5C,   0x107940,       0x107800,   0x101BC8,   0x323FEC,   0x1027F8,   0x1070E4),
-			new HeaderData(0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0),
-			new HeaderData(0x11E214, 0x0D50FC,	0x5A2E80,	0xFF850,	0x108398,	0x108050,	0x1083AE,	0x1083C4,	0x108408,	0x1081E4,		0x1080A4,	0x10246C,	0x324AE4,	0x10309C,	0x107988)
-		};
+            new HeaderData(0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0),
+            new HeaderData(0x11E214, 0x0D50FC,  0x5A2E80, 0xFF850,  0x108398, 0x108050, 0x1083AE, 0x1083C4, 0x108408, 0x1081E4,   0x1080A4, 0x10246C, 0x324AE4, 0x10309C, 0x107988)
+        };
 
-		public HeaderData GetHeaderAddresses( RegionVersion region )
-		{
-			return headerTable[(int)region];
-		}
-	}
+        public HeaderData GetHeaderAddresses(RegionVersion region)
+        {
+            return headerTable[(int)region];
+        }
+    }
 }

--- a/Core/EventDefine.cs
+++ b/Core/EventDefine.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace MinishRandomizer.Core
 {

--- a/Core/ROM.cs
+++ b/Core/ROM.cs
@@ -1,7 +1,6 @@
-﻿using System;
 using System.Diagnostics;
-using MinishRandomizer.Utilities;
 using System.IO;
+using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer.Core
 {
@@ -13,7 +12,7 @@ namespace MinishRandomizer.Core
         public readonly byte[] romData;
         public readonly Reader reader;
 
-        public RegionVersion version { get; private set;  } = RegionVersion.None;
+        public RegionVersion version { get; private set; } = RegionVersion.None;
         public HeaderData headers { get; private set; }
 
 
@@ -44,7 +43,7 @@ namespace MinishRandomizer.Core
             // Determine game region and if valid ROM
             byte[] regionBytes = reader.ReadBytes(4, 0xAC);
             string region = System.Text.Encoding.UTF8.GetString(regionBytes);
-            Debug.WriteLine("Region detected: "+region);
+            Debug.WriteLine("Region detected: " + region);
 
             if (region == "BZMP")
             {

--- a/Randomizer/Logic/Dependency.cs
+++ b/Randomizer/Logic/Dependency.cs
@@ -1,8 +1,4 @@
-﻿using MinishRandomizer.Core;
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text.RegularExpressions;
 
 namespace MinishRandomizer.Randomizer.Logic
 {

--- a/Randomizer/Logic/DirectiveParser.cs
+++ b/Randomizer/Logic/DirectiveParser.cs
@@ -1,15 +1,12 @@
-﻿using MinishRandomizer.Core;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using MinishRandomizer.Core;
 
 namespace MinishRandomizer.Randomizer.Logic
 {
-
     public class DirectiveParser
     {
         public uint? RomCrc;
@@ -267,7 +264,7 @@ namespace MinishRandomizer.Randomizer.Logic
         {
             List<LogicOption> gimmicks = Options.Where(option => option.Type == LogicOptionType.Gimmick).ToList();
             byte[] bytes = new byte[gimmicks.Count];
-            
+
             for (int i = 0; i < gimmicks.Count; i++)
             {
                 bytes[i] = gimmicks[i].GetHashByte();
@@ -288,7 +285,7 @@ namespace MinishRandomizer.Randomizer.Logic
 
         public void ClearTypeOverrides()
         {
-           LocationTypeOverrides.Clear();
+            LocationTypeOverrides.Clear();
         }
 
         public void AddOptions()
@@ -424,7 +421,8 @@ namespace MinishRandomizer.Randomizer.Logic
             {
                 return new EventDefine(directiveParts[1]);
             }
-            else if (directiveParts.Length == 3) {
+            else if (directiveParts.Length == 3)
+            {
                 return new EventDefine(directiveParts[1], directiveParts[2]);
             }
             else
@@ -479,7 +477,7 @@ namespace MinishRandomizer.Randomizer.Logic
                 throw new ParserException("!replace has an invalid replaced itemType");
             }
 
-            
+
             if (itemStrings.Length >= 3)
             {
                 if (!byte.TryParse(itemStrings[2], NumberStyles.HexNumber, null, out itemsub))
@@ -495,10 +493,10 @@ namespace MinishRandomizer.Randomizer.Logic
             }
 
             replacedItem = new Item(type, itemsub, dungeonString);
-            
+
             foreach (var chanceItem in chanceItems)
             {
-                
+
                 var chanceItemData = chanceItem.TrimEnd(';').Split(':');
                 var chanceItemStrings = chanceItemData[0].Split('.');
 
@@ -571,7 +569,7 @@ namespace MinishRandomizer.Randomizer.Logic
             }
 
             LocationTypeOverrides.Add(replacedItem, newType);
-            
+
         }
 
 
@@ -591,7 +589,7 @@ namespace MinishRandomizer.Randomizer.Logic
                 }
             }
         }
-        
+
         public struct ChanceItem
         {
             public Item item;

--- a/Randomizer/Logic/Location.cs
+++ b/Randomizer/Logic/Location.cs
@@ -1,10 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using MinishRandomizer.Core;
 using MinishRandomizer.Utilities;
 

--- a/Randomizer/Logic/LocationAddress.cs
+++ b/Randomizer/Logic/LocationAddress.cs
@@ -1,11 +1,7 @@
-﻿using MinishRandomizer.Utilities;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using MinishRandomizer.Core;
-using System.IO;
+using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer.Randomizer.Logic
 {

--- a/Randomizer/Logic/LogicDefine.cs
+++ b/Randomizer/Logic/LogicDefine.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace MinishRandomizer.Randomizer.Logic
 {

--- a/Randomizer/Logic/LogicOption.cs
+++ b/Randomizer/Logic/LogicOption.cs
@@ -1,10 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
 using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer.Randomizer.Logic
@@ -139,7 +137,7 @@ namespace MinishRandomizer.Randomizer.Logic
         public override List<LogicDefine> GetLogicDefines()
         {
             List<LogicDefine> defineList = new List<LogicDefine>(3);
-            
+
             // Only true if a color has been selected
             if (Active)
             {
@@ -183,7 +181,7 @@ namespace MinishRandomizer.Randomizer.Logic
                 DataSource = Selections.Keys.ToList()
             };
 
-            comboBox.SelectedValueChanged += (object sender, EventArgs e) => { Selection = (string)comboBox.SelectedValue;  SelectedNumber = comboBox.SelectedIndex; };
+            comboBox.SelectedValueChanged += (object sender, EventArgs e) => { Selection = (string)comboBox.SelectedValue; SelectedNumber = comboBox.SelectedIndex; };
 
             return comboBox;
         }

--- a/Randomizer/Logic/Parser.cs
+++ b/Randomizer/Logic/Parser.cs
@@ -1,15 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MinishRandomizer.Core;
 using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer.Randomizer.Logic
 {
-    public class ParserException : Exception {
+    public class ParserException : Exception
+    {
         public ParserException(string message) : base(message) { }
     }
 
@@ -62,7 +60,7 @@ namespace MinishRandomizer.Randomizer.Logic
                         {
                             throw new ParserException($"Invalid total for counter! {reqValueString.Substring(1)}");
                         }
-                        string[] itemStrings = sequence.Substring(reqValueString.Length+1).Split(',');
+                        string[] itemStrings = sequence.Substring(reqValueString.Length + 1).Split(',');
 
                         foreach (var itemString in itemStrings)
                         {
@@ -91,7 +89,7 @@ namespace MinishRandomizer.Randomizer.Logic
 
                             byte itemSub = 0;
 
-                            if (itemParts.Length >= 3) 
+                            if (itemParts.Length >= 3)
                             {
                                 if (!byte.TryParse(itemParts[2], out itemSub))
                                 {

--- a/Randomizer/Shuffler.cs
+++ b/Randomizer/Shuffler.cs
@@ -1,16 +1,17 @@
-﻿using MinishRandomizer.Core;
-using MinishRandomizer.Randomizer.Logic;
-using MinishRandomizer.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using MinishRandomizer.Core;
+using MinishRandomizer.Randomizer.Logic;
+using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer.Randomizer
 {
-    public class ShuffleException : Exception {
+    public class ShuffleException : Exception
+    {
         public ShuffleException(string message) : base(message) { }
     }
 
@@ -120,7 +121,7 @@ namespace MinishRandomizer.Randomizer
             {
                 return 0;
             }
-            
+
         }
 
         public uint GetGimmickHash()
@@ -369,7 +370,7 @@ namespace MinishRandomizer.Randomizer
                 {
                     Console.WriteLine($"Dungeon: {item.Dungeon}");
                 }
-                
+
                 // Take item out of pool
                 items.RemoveAt(itemIndex);
 

--- a/UI/MainWindow.cs
+++ b/UI/MainWindow.cs
@@ -1,11 +1,11 @@
-﻿using MinishRandomizer.Core;
-using MinishRandomizer.Randomizer;
-using MinishRandomizer.Randomizer.Logic;
-using MinishRandomizer.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
+using MinishRandomizer.Core;
+using MinishRandomizer.Randomizer;
+using MinishRandomizer.Randomizer.Logic;
+using MinishRandomizer.Utilities;
 
 namespace MinishRandomizer
 {
@@ -77,7 +77,7 @@ namespace MinishRandomizer
                         shuffler.LoadLocations();
                     }
 
-                    
+
                     shuffler.RandomizeLocations();
                 }
                 else
@@ -268,7 +268,7 @@ namespace MinishRandomizer
 
             if (customPatchCheckBox.Checked)
             {
-                
+
                 shuffler.ApplyPatch(sfd.FileName, customPatchPath.Text);
             }
             else
@@ -336,7 +336,7 @@ namespace MinishRandomizer
             // If there options, show the options tab
             if (options.Count >= 1)
             {
-                
+
                 // Make sure not to add the tab multiple times
                 if (!mainTabs.TabPages.Contains(optionTabPage))
                 {

--- a/Utilities/ColorUtil.cs
+++ b/Utilities/ColorUtil.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MinishRandomizer.Utilities
 {
     public static class ColorExtensions
     {
-        
-
-        
     }
 
     public static class ColorUtil

--- a/Utilities/ExtensionMethods.cs
+++ b/Utilities/ExtensionMethods.cs
@@ -1,37 +1,34 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MinishRandomizer.Utilities
 {
-	public static class ExtensionMethods
-	{
-		public static string Hex( this uint num )
-		{
-			return Convert.ToString( num, 16 ).ToUpper();
-		}
+    public static class ExtensionMethods
+    {
+        public static string Hex(this uint num)
+        {
+            return Convert.ToString(num, 16).ToUpper();
+        }
 
-		public static string Hex( this int num )
-		{
-			return Convert.ToString( num, 16 ).ToUpper();
-		}
+        public static string Hex(this int num)
+        {
+            return Convert.ToString(num, 16).ToUpper();
+        }
 
-		public static string Hex( this long num )
-		{
-			return Convert.ToString( num, 16 ).ToUpper();
-		}
+        public static string Hex(this long num)
+        {
+            return Convert.ToString(num, 16).ToUpper();
+        }
 
-		public static string Hex( this ushort num )
-		{
-			return Convert.ToString( num, 16 ).ToUpper();
-		}
+        public static string Hex(this ushort num)
+        {
+            return Convert.ToString(num, 16).ToUpper();
+        }
 
-		public static string Hex( this byte num )
-		{
-			return Convert.ToString( num, 16 ).ToUpper();
-		}
+        public static string Hex(this byte num)
+        {
+            return Convert.ToString(num, 16).ToUpper();
+        }
 
         public static void Shuffle<T>(this IList<T> list, Random rng)
         {

--- a/Utilities/PatchUtil.cs
+++ b/Utilities/PatchUtil.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MinishRandomizer.Utilities
 {
-    static class PatchUtil {
+    static class PatchUtil
+    {
         /// <summary>
         /// Apply a UPS patch to a byte array, in place
         /// </summary>

--- a/Utilities/StringUtil.cs
+++ b/Utilities/StringUtil.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-namespace MinishRandomizer.Utilities
+﻿namespace MinishRandomizer.Utilities
 {
     class StringUtil
-    {   
+    {
         // Convert values to hex strings
         public static string AsStringHex(int val, int spacing)
         {

--- a/Utilities/Writer.cs
+++ b/Utilities/Writer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace MinishRandomizer.Utilities
 {


### PR DESCRIPTION
This ensures the code files have a clean, consistent look and feel.

* Tabs vs spaces are resolved to spaces.
* Braces follow the Allman style throughout.
* Any unused using statements were removed, and the remaining ones were sorted, System ones first.

Some more changes are aimed for the future, but I wish to start small.

While an `.editorconfig` file was used to ensure consistency, that file is not ready for distribution. There are some other style issues that may need agreeing upon before I go ahead with any other proposals.

This replaces #5.