### PR TITLE
Include .editorconfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# The editorconfig file inspired by Microsoft's guidelines for Roslyn.
+
+[*]
+# Line endings should use the windows format.
+end_of_line = crlf
+
+# Dotnet code stylings should come first in case we ever mess with VB.
+[*.{cs,vb}]
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+
+# System namespaces come first.
+dotnet_sort_system_directives_first = true
+
+# Language keywords are prefered over framework types.
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# CSharp specific items come after.
+[*.cs]
+
+csharp_new_line_before_open_brace = all
+
+# Space preferences.
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_cast = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_between_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false

--- a/MinishRandomizer.csproj
+++ b/MinishRandomizer.csproj
@@ -88,6 +88,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include=".editorconfig" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Utilities/ColorUtil.cs
+++ b/Utilities/ColorUtil.cs
@@ -63,7 +63,7 @@ namespace MinishRandomizer.Utilities
                 || 255 < alpha)
             {
                 throw new ArgumentOutOfRangeException(
-                    "alpha",
+                    nameof(alpha),
                     alpha,
                     "Value must be within a range of 0 - 255.");
             }
@@ -72,7 +72,7 @@ namespace MinishRandomizer.Utilities
                 || 360f < hue)
             {
                 throw new ArgumentOutOfRangeException(
-                    "hue",
+                    nameof(hue),
                     hue,
                     "Value must be within a range of 0 - 360.");
             }
@@ -81,7 +81,7 @@ namespace MinishRandomizer.Utilities
                 || 1f < saturation)
             {
                 throw new ArgumentOutOfRangeException(
-                    "saturation",
+                    nameof(saturation),
                     saturation,
                     "Value must be within a range of 0 - 1.");
             }
@@ -90,7 +90,7 @@ namespace MinishRandomizer.Utilities
                 || 1f < brightness)
             {
                 throw new ArgumentOutOfRangeException(
-                    "brightness",
+                    nameof(brightness),
                     brightness,
                     "Value must be within a range of 0 - 1.");
             }


### PR DESCRIPTION
This file will ensure that when we format code using `Control K + Control D` (assuming default shortcuts), the code will format itself to a style appropriate for this repository. This way, those of us who work with other repositories that force other code styles will hopefully not have to worry as much about changing settings whenever different repositories are open.

Note that more rules could be added explicitly, but the ones provided at least do not cause problems for me compared to my own work environment. More rules could (and probably should) be added in the future to help ensure consistency for other contributors.

Some other minor things were done (mostly utilizing `nameof` where possible and one minor line to trim out), but the core is the .editorconfig file.