### PR TITLE
Require total placed figurines for Ped

### DIFF
--- a/Resources/default.logic
+++ b/Resources/default.logic
@@ -240,7 +240,7 @@
             !replaceincrement - Items.KinstoneBag.01 - `FIGURINE_TOTAL` - `SHELLVALS` `KINVALS`
             !settype - Items.KinstoneBag.* - Major
             !undefine - DHC_FIG
-            !define - DHC_FIG - ,Items.KinstoneBag.*::`FIGURINE_COUNT`
+            !define - DHC_FIG - ,Items.KinstoneBag.*::`FIGURINE_TOTAL`
         !endif
     !endif
 !endif


### PR DESCRIPTION
This is a workaround for #27
It also eliminates the possibility of placing extra figurines in DHC in Ped Open figurine hunt seeds.