### PR TITLE
fix CLI build

### DIFF
--- a/RandomizerCore/Controllers/Models/ShufflerControllerResult.cs
+++ b/RandomizerCore/Controllers/Models/ShufflerControllerResult.cs
@@ -7,5 +7,7 @@
 		public Exception? Error { get; set; }
 
 		public string? ErrorMessage { get; set; }
+
+		public static implicit operator bool(ShufflerControllerResult result) => result.WasSuccessful;
 	}
 }


### PR DESCRIPTION
I decided to use an `operator bool` on the `ShufflerControllerResult` type, rather than adding `.WasSuccessful` everywhere.
Allows to do things like `if(result)` rather than `if(result.WasSuccessful)` which leads to easier to read and write code in my opinion.
Fixes #52 