### PR TITLE
improve non interactive CLI

### DIFF
--- a/MinishCapRandomizerCLI/Program.cs
+++ b/MinishCapRandomizerCLI/Program.cs
@@ -34,18 +34,11 @@ internal class Program
             if (string.IsNullOrEmpty(command) || !_commands.ContainsKey(command))
             {
                 Console.WriteLine($"Invalid command entered! {command} is not a valid command!");
-                BlockUntilNewline();
                 continue;
             }
             
             _commands[command].Invoke();
         }
-    }
-
-    private static void BlockUntilNewline()
-    {
-        Console.WriteLine("Press enter to continue...");
-        Console.ReadLine();
     }
 
     private static void LoadCommands()
@@ -105,7 +98,6 @@ Exit                Exits the program
         {
             Console.WriteLine("Failed to load ROM! Please check your file path and make sure you have read access.");
         }
-        BlockUntilNewline();
     }
     
     private static void Seed()
@@ -140,8 +132,6 @@ Exit                Exits the program
             }
         }
         else Console.WriteLine("Invalid input!");
-        
-        BlockUntilNewline();
     }
     
     private static void LoadLogic()
@@ -157,7 +147,6 @@ Exit                Exits the program
         {
             Console.WriteLine("Failed to load Logic File! Please check your file path and make sure you have read access.");
         }
-        BlockUntilNewline();
     }
     
     private static void LoadPatch()
@@ -165,7 +154,6 @@ Exit                Exits the program
         Console.Write("Please enter the path to the Patch File you want to use (leave empty to use default patch): ");
         _cachedPatchPath = Console.ReadLine();
         Console.WriteLine("Patch file loaded successfully!");
-        BlockUntilNewline();
     }
     
     private static void LoadSettings()
@@ -174,7 +162,6 @@ Exit                Exits the program
         var input = Console.ReadLine();
         if (!string.IsNullOrEmpty(input)) _shufflerController.LoadSettingsFromSettingString(input);
         Console.WriteLine("Settings loaded successfully!");
-        BlockUntilNewline();
     }
     
     private static void Options()
@@ -225,7 +212,6 @@ Exit                Exits the program
             Console.Write("Please enter the number of the setting you would like to change, enter \"Exit\" to stop editing, or enter \"List\" to list all of the options again: ");
             input = Console.ReadLine();
         }
-        BlockUntilNewline();
     }
     
     private static void Logging()
@@ -238,7 +224,6 @@ Exit                Exits the program
         if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i))
         {
             Console.WriteLine("Invalid Input!");
-            BlockUntilNewline();
             return;
         }
 
@@ -254,7 +239,6 @@ Exit                Exits the program
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out i) || (i != 1 && i != 2))
                 {
                     Console.WriteLine("Invalid Input!");
-                    BlockUntilNewline();
                     return;
                 }
                 _shufflerController.SetLoggerVerbosity(i == 1);
@@ -274,10 +258,8 @@ Exit                Exits the program
                 break;
             default:
                 Console.WriteLine("Invalid Input!");
-                BlockUntilNewline();
                 return;
         }
-        BlockUntilNewline();
     }
     
     private static void Randomize()
@@ -289,7 +271,6 @@ Exit                Exits the program
         _shufflerController.LoadLocations(_cachedLogicPath);
         var success = _shufflerController.Randomize(attempts);
         Console.WriteLine(success ? "Randomization successful!" : "Randomization failed! Please try again!");
-        BlockUntilNewline();
     }
     
     private static void SaveRom()
@@ -305,7 +286,6 @@ Exit                Exits the program
         {
             Console.WriteLine("Failed to save ROM! Please check your file path and make sure you have write access.");
         }
-        BlockUntilNewline();
     }
     
     private static void SaveSpoiler()
@@ -321,7 +301,6 @@ Exit                Exits the program
         {
             Console.WriteLine("Failed to save spoiler! Please check your file path and make sure you have write access.");
         }
-        BlockUntilNewline();
     }
 
     private static void SavePatch()
@@ -337,14 +316,12 @@ Exit                Exits the program
         {
             Console.WriteLine("Failed to save patch! Please check your file path and make sure you have write access.");
         }
-        BlockUntilNewline();
     }
     
     private static void GetSettingString()
     {
         Console.WriteLine("Setting String:");
         Console.WriteLine(_shufflerController.GetSettingsString());
-        BlockUntilNewline();
     }
     
     private static void PatchRom()
@@ -361,8 +338,6 @@ Exit                Exits the program
         Console.WriteLine(!result
             ? "Failed to patch ROM! Please check your file paths and make sure you have read/write access."
             : "Rom patched successfully!");
-
-        BlockUntilNewline();
     }
 
     private static void CreatePatch()
@@ -378,8 +353,6 @@ Exit                Exits the program
         Console.WriteLine(!result
             ? "Failed to save patch! Please check your file paths and make sure you have read/write access."
             : "Patch saved successfully!");
-        
-        BlockUntilNewline();
     }
     
     private static void Exit()
@@ -394,7 +367,6 @@ Exit                Exits the program
         }
 
         _exiting = response.Equals("yes", StringComparison.OrdinalIgnoreCase);
-        BlockUntilNewline();
     }
 
     private static void EditOption(LogicOptionBase option)
@@ -410,13 +382,11 @@ Exit                Exits the program
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || (i != 1 && i != 2))
                 {
                     Console.WriteLine("Invalid Input!");
-                    BlockUntilNewline();
                     break;
                 }
 
                 option.Active = i == 1;
                 Console.WriteLine("Flag set successfully!");
-                BlockUntilNewline();
                 break;
             }
             case LogicDropdown dropdown:
@@ -434,13 +404,11 @@ Exit                Exits the program
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var o) || o < 1 || o > keys.Count)
                 {
                     Console.WriteLine("Invalid Input!");
-                    BlockUntilNewline();
                     break;
                 }
 
                 dropdown.Selection = keys[o - 1];
                 Console.WriteLine("Dropdown option set successfully!");
-                BlockUntilNewline();
                 break;
             }            
             case LogicColorPicker colorPicker:
@@ -454,7 +422,6 @@ Exit                Exits the program
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || i is < 1 or > 4)
                 {
                     Console.WriteLine("Invalid Input!");
-                    BlockUntilNewline();
                     break;
                 }
 
@@ -485,7 +452,6 @@ Exit                Exits the program
                         Console.WriteLine("Color set successfully!");
                         break;
                 }
-                BlockUntilNewline();
                 break;
             }
             case LogicNumberBox box:
@@ -495,13 +461,11 @@ Exit                Exits the program
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || i is < 0 or > 255)
                 {
                     Console.WriteLine("Invalid Input!");
-                    BlockUntilNewline();
                     break;
                 }
 
                 box.Value = input;
                 Console.WriteLine("Number box value set successfully!");
-                BlockUntilNewline();
                 break;
             }
         }

--- a/MinishCapRandomizerCLI/Program.cs
+++ b/MinishCapRandomizerCLI/Program.cs
@@ -202,7 +202,22 @@ Exit                Exits the program
                 }
                 else
                 {
-                    Console.WriteLine("Invalid Input!");
+                    if (options.Exists(option => String.Equals(option.Name, input)))
+                    {
+                        var option = options.Find(option => String.Equals(option.Name, input));
+                        if (option != null)
+                        {
+                            EditOption(option);
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Unknown Option {input}!");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Unknown Option {input}!");
+                    }
                 }
             }
             else

--- a/MinishCapRandomizerCLI/Program.cs
+++ b/MinishCapRandomizerCLI/Program.cs
@@ -357,16 +357,7 @@ Exit                Exits the program
     
     private static void Exit()
     {
-        Console.Write("Are you sure you want to exit? (Yes or No): ");
-        var response = Console.ReadLine();
-        while (string.IsNullOrEmpty(response) || (!response.Equals("yes", StringComparison.OrdinalIgnoreCase) && 
-                                                  !response.Equals("no", StringComparison.OrdinalIgnoreCase)))
-        {
-            Console.Write("Invalid input! Please enter Yes or No: ");
-            response = Console.ReadLine();
-        }
-
-        _exiting = response.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        _exiting = true;
     }
 
     private static void EditOption(LogicOptionBase option)

--- a/MinishCapRandomizerCLI/Program.cs
+++ b/MinishCapRandomizerCLI/Program.cs
@@ -385,7 +385,7 @@ Exit                Exits the program
                 Console.WriteLine("2) Disabled");
                 Console.Write("Enter the number of the option to set the flag to: ");
                 var input = Console.ReadLine();
-                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || (i != 1 && i != 2))
+                if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || (i != 0 && i != 1 && i != 2))
                 {
                     Console.WriteLine("Invalid Input!");
                     break;


### PR DESCRIPTION
One of the biggest advantages of the CLI is the ability to use it non-interactively by using a file with commands as the input.
In it's current state that is possible, but not very nice to use.
This PR improves the CLI, especially with respect to non-interactive use.
The changes are:
- remove the `Press enter to continue...` prompt. This is annoying, but in interactive and non interactive use.
- remove the confirmation prompt on the `Exit` command. In a CLI this is somewhat redundant and just bloats command files.
- allow using option names instead of their list index in the `Options` commands submenu. This is important, since otherwise any added/removed/reordered option would break all command files. (like removing the `FIGURINE_HUNT` option breaking not only files that use it, but also most other files since now many other options get moved up in the list and have their index changed)
- allow using `0` in addition to `2` for disabling flag type options. this is an aesthetic choice, in line with the common `false=0` and `true=1`. `2` is still allowed for consistency with other option types, which have all their input choices indexed from 1. (also backwards compatibility, but thats not really a big deal at this point in the CLI development process)
- add a strict mode (toggled by the new `Strict` command) that makes the CLI exit on error instead of continuing. This is preferred in a non-interactive environment.
- errors are now printed to stderr

With these changes the CLI is still far from being in a clean state, but it will be well usable in a non-interactive environment.