### PR TITLE
Fixed bug with elements being placed in inaccessible locations

### DIFF
--- a/RandomizerCore/Controllers/ShufflerController.cs
+++ b/RandomizerCore/Controllers/ShufflerController.cs
@@ -32,7 +32,7 @@ public class ShufflerController
     public string RevName => RevisionIdentifier;
 
     internal static string VersionIdentifier => "v0.7.0";
-    internal static string RevisionIdentifier => "alpha-rev3";
+    internal static string RevisionIdentifier => "alpha-rev3-hotfix";
 
     public string SeedFilename =>
         $"Minish Randomizer-{Shuffler.Seed}-{Shuffler.Version}-{Shuffler.GetOptionsIdentifier()}";

--- a/RandomizerCore/Randomizer/Shuffler.cs
+++ b/RandomizerCore/Randomizer/Shuffler.cs
@@ -492,7 +492,8 @@ internal class Shuffler
         FilledLocations.AddRange(nextLocationGroup);
 
         //Grab all items that we need to beat the seed
-        var allItems = MajorItems.Concat(DungeonMajorItems).Concat(DungeonEntrances).ToList();
+        var allItems = MajorItems.Concat(DungeonMajorItems).ToList();
+        var allItemsAndEntrances = MajorItems.Concat(DungeonMajorItems).Concat(DungeonEntrances).ToList();
 
         //Like entrances, constraints shouldn't check logic when placing
         //Shuffle constraints
@@ -526,7 +527,7 @@ internal class Shuffler
         //Shuffle dungeon minors
         unfilledLocations.AddRange(FillLocationsFrontToBack(DungeonMinorItems,
             unfilledLocations,
-            allItems));
+            allItemsAndEntrances));
 
         unfilledLocations = unfilledLocations.Distinct().ToList();
 


### PR DESCRIPTION
It got merged like 20 seconds before I pushed this change 🙃 

Fixes a dumb bug I introduced with the hotfix, passed 100 seed generation with random settings (100 successful settings, 3 failures, at least one of which was because the settings were impossible to ever finish)

Also adds hotfix to the title

Commands passed into the CLI for the 100 seed test:

LoadRom (Path to rom)
Logging 2 (Path to log file)
BulkGenerateSeeds 100 true
Logging 3
Exit

Issue with a couple of the failures seems to be a very rare case of all the spots available for spin scrolls being used up, although this is extremely rare.

Failed strings:
NlgC5VAAQTDeawGroAQABAAgQgAgQRQRAgAQAAgQQQwQAQAggQggQAQAAQQAAQQAAhUQFB4=
NlgC5VAAQUP8fm9oxABgQAAQAgAQQAwQwAAQQAQgQAgQAQQAxQggAQgAQQQAQAAQQREAFB4=
NlgC5VAAQXTzriD/SABgAAQwAQQgAAwSAAQAQAAAQwQAQQAgAQgwQAgAQQQQAQQQAACwFB4= (This one is impossible to finish, 6 dungeons required but only 4 accessible)