### PR TITLE
Color UI changes

### DIFF
--- a/MinishCapRandomizerUI/Elements/ColorPickerWrapper.cs
+++ b/MinishCapRandomizerUI/Elements/ColorPickerWrapper.cs
@@ -7,21 +7,25 @@ namespace MinishCapRandomizerUI.Elements;
 public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
 {
     private const int DefaultBottomMargin = 11; 
-    private const int CheckboxWidth = 155;
+    private const int CheckboxWidth = 130;
     private const int CheckboxHeight = 19;
-    private const int TextWidth = 85;
+    private const int TextWidth = 60;
     private const int TextHeight = 19;
-    private const int ButtonWidth = 130;
+    private const int ButtonWidth = 100;
     private const int ButtonHeight = 23;
     private const int PictureBoxWidth = 60;
     private const int PictureBoxHeight = 23;
     private const int TextAlign = 1;
     private const int ButtonAndPictureBoxAlign = -3;
     private const string CheckboxText = "Use Random Color";
-    private const string SelectColorText = "Select Custom Color";
-    private const string SelectRandomColorText = "Pick Random Color";
-    private const string UseDefaultColorText = "Use Default Color";
-    private const string ColorPreviewText = "Color Preview:";
+    private const string CheckboxToolTip = "If enabled, a random color will be selected on seed generation";
+    private const string SelectColorText = "Select Color";
+    private const string SelectColorToolTip = "Opens the custom color picker";
+    private const string SelectRandomColorText = "Pick Random";
+    private const string SelectRandomColorToolTip = "A random color is selected now and shown in the preview";
+    private const string UseDefaultColorText = "Use Default";
+    private const string UseDefaultColorToolTip = "Resets the selected color back to its default";
+    private const string ColorPreviewText = "Preview:";
 
     private new static readonly int ElementWidth = CheckboxWidth + TextWidth + PictureBoxWidth + 3 * ButtonWidth + 5 * Constants.WidthMargin; // one row
     private new const int ElementHeight = CheckboxHeight + DefaultBottomMargin;
@@ -33,6 +37,7 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
     private Label? _label;
     private PictureBox? _colorPreview;
     private LogicColorPicker _colorPicker;
+    private ToolTip tip;
 
     public ColorPickerWrapper(LogicColorPicker colorPicker) : base(ElementWidth, ElementHeight, colorPicker.SettingGroup, colorPicker.SettingPage)
     {
@@ -51,6 +56,13 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
             };
         }
 
+        tip = new ToolTip();
+        tip.UseFading = true;
+        tip.AutoPopDelay = Constants.TooltipDisplayLengthMs;
+        tip.InitialDelay = Constants.TooltipInitialShowDelayMs;
+        tip.ReshowDelay = Constants.TooltipRepeatDelayMs;
+        tip.ShowAlways = true;
+
         _checkBox = new CheckBox
         {
             AutoEllipsis = Constants.LabelsAndCheckboxesUseAutoEllipsis,
@@ -66,14 +78,14 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
 
         var nextElementX = initialX + (int)((CheckboxWidth + Constants.WidthMargin)*Constants.SpecialScaling);
 
-        _selectColorButton = BuildButton((sender, args) => SelectColor(), 
-            "SelectColorButton", SelectColorText, ref nextElementX, initialY + ButtonAndPictureBoxAlign); 
+        _selectColorButton = BuildButton((sender, args) => SelectColor(), "SelectColorButton", 
+            SelectColorText, SelectColorToolTip, ref nextElementX, initialY + ButtonAndPictureBoxAlign); 
 
-        _selectRandomColorButton = BuildButton((sender, args) => SelectRandomColor(), 
-            "RandomColorButton", SelectRandomColorText, ref nextElementX, initialY + ButtonAndPictureBoxAlign);
+        _selectRandomColorButton = BuildButton((sender, args) => SelectRandomColor(), "RandomColorButton", 
+            SelectRandomColorText, SelectRandomColorToolTip, ref nextElementX, initialY + ButtonAndPictureBoxAlign);
 
-        _useDefaultColorButton = BuildButton((sender, args) => SelectDefaultColor(), 
-            "DefaultColorButton", UseDefaultColorText, ref nextElementX, initialY + ButtonAndPictureBoxAlign);
+        _useDefaultColorButton = BuildButton((sender, args) => SelectDefaultColor(), "DefaultColorButton", 
+            UseDefaultColorText, UseDefaultColorToolTip, ref nextElementX, initialY + ButtonAndPictureBoxAlign);
         
         _label = new Label
         {
@@ -110,6 +122,8 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
             else _colorPreview.BackColor = _colorPicker.DefinedColor;
         };
 
+        tip.SetToolTip(_checkBox, CheckboxToolTip);
+
         return new List<Control>
         {
             _checkBox, _selectColorButton, _selectRandomColorButton, _useDefaultColorButton, _label, _colorPreview
@@ -120,12 +134,12 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
         EventHandler onClickEvent, 
         string name, 
         string text, 
+        string toolTipText, 
         ref int xPosition, 
         int yPosition)
     {
         var button = new Button
         {
-            AutoEllipsis = Constants.LabelsAndCheckboxesUseAutoEllipsis,
             AutoSize = false,
             Enabled = true,
             Name = name,
@@ -136,6 +150,8 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
             BackColor = Constants.DefaultButtonBackgroundColor,
             UseMnemonic = Constants.UseMnemonic,
         };
+
+        tip.SetToolTip(button, toolTipText);
 
         button.Click += onClickEvent;
         

--- a/MinishCapRandomizerUI/Elements/ColorPickerWrapper.cs
+++ b/MinishCapRandomizerUI/Elements/ColorPickerWrapper.cs
@@ -6,11 +6,13 @@ namespace MinishCapRandomizerUI.Elements;
 
 public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
 {
-    private const int DefaultBottomMargin = 11; 
-    private const int CheckboxWidth = 130;
+    private const int DefaultBottomMargin = 11;
+    private const int NameTextWidth = 125;
+    private const int NameTextHeight = 19;
+    private const int CheckboxWidth = 125;
     private const int CheckboxHeight = 19;
-    private const int TextWidth = 60;
-    private const int TextHeight = 19;
+    private const int PreviewTextWidth = 55;
+    private const int PreviewTextHeight = 19;
     private const int ButtonWidth = 100;
     private const int ButtonHeight = 23;
     private const int PictureBoxWidth = 60;
@@ -27,14 +29,15 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
     private const string UseDefaultColorToolTip = "Resets the selected color back to its default";
     private const string ColorPreviewText = "Preview:";
 
-    private new static readonly int ElementWidth = CheckboxWidth + TextWidth + PictureBoxWidth + 3 * ButtonWidth + 5 * Constants.WidthMargin; // one row
+    private new static readonly int ElementWidth = CheckboxWidth + NameTextWidth + PreviewTextWidth + PictureBoxWidth + 3 * ButtonWidth + 7 * Constants.WidthMargin; // one row
     private new const int ElementHeight = CheckboxHeight + DefaultBottomMargin;
 
+    private Label? _nameLabel;
     private CheckBox? _checkBox;
     private Button? _selectColorButton;
     private Button? _selectRandomColorButton;
     private Button? _useDefaultColorButton;
-    private Label? _label;
+    private Label? _previewLabel;
     private PictureBox? _colorPreview;
     private LogicColorPicker _colorPicker;
     private ToolTip tip;
@@ -47,12 +50,12 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
 
     public override List<Control> GetControls(int initialX, int initialY)
     {
-        if (_checkBox != null && _selectColorButton != null && _selectRandomColorButton != null &&
-            _useDefaultColorButton != null && _label != null && _colorPreview != null)
+        if (_nameLabel != null && _checkBox != null && _selectColorButton != null && _selectRandomColorButton != null &&
+            _useDefaultColorButton != null && _previewLabel != null && _colorPreview != null)
         {
             return new List<Control>
             {
-                _checkBox, _selectColorButton, _selectRandomColorButton, _useDefaultColorButton, _label, _colorPreview
+                _nameLabel, _checkBox, _selectColorButton, _selectRandomColorButton, _useDefaultColorButton, _previewLabel, _colorPreview
             };
         }
 
@@ -63,20 +66,37 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
         tip.ReshowDelay = Constants.TooltipRepeatDelayMs;
         tip.ShowAlways = true;
 
+        _nameLabel = new Label
+        {
+            AutoEllipsis = Constants.LabelsAndCheckboxesUseAutoEllipsis,
+            AutoSize = false,
+            Name = _colorPicker.Name,
+            Text = _colorPicker.NiceName + ":",
+            Location = new Point(initialX, initialY),
+            Height = (int)(NameTextHeight*Constants.SpecialScaling),
+            Width = (int)(NameTextWidth*Constants.SpecialScaling),
+            TextAlign = ContentAlignment.MiddleRight,
+            UseMnemonic = Constants.UseMnemonic,
+        };
+
+        tip.SetToolTip(_nameLabel, _colorPicker.DescriptionText);
+
+        var nextElementX = initialX + (int)((NameTextWidth + Constants.WidthMargin*2)*Constants.SpecialScaling);
+
         _checkBox = new CheckBox
         {
             AutoEllipsis = Constants.LabelsAndCheckboxesUseAutoEllipsis,
             AutoSize = false,
             Checked = false,
             Name = "Checkbox",
-            Location = new Point(initialX, initialY),
+            Location = new Point(nextElementX, initialY),
             Height = (int)(CheckboxHeight*Constants.SpecialScaling),
             Width = (int)(CheckboxWidth*Constants.SpecialScaling),
             Text = CheckboxText,
             UseMnemonic = Constants.UseMnemonic,
         };
 
-        var nextElementX = initialX + (int)((CheckboxWidth + Constants.WidthMargin)*Constants.SpecialScaling);
+        nextElementX += (int)((CheckboxWidth + Constants.WidthMargin)*Constants.SpecialScaling);
 
         _selectColorButton = BuildButton((sender, args) => SelectColor(), "SelectColorButton", 
             SelectColorText, SelectColorToolTip, ref nextElementX, initialY + ButtonAndPictureBoxAlign); 
@@ -87,19 +107,19 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
         _useDefaultColorButton = BuildButton((sender, args) => SelectDefaultColor(), "DefaultColorButton", 
             UseDefaultColorText, UseDefaultColorToolTip, ref nextElementX, initialY + ButtonAndPictureBoxAlign);
         
-        _label = new Label
+        _previewLabel = new Label
         {
             AutoEllipsis = Constants.LabelsAndCheckboxesUseAutoEllipsis,
             AutoSize = false,
             Name = "ColorPreviewLabel",
             Location = new Point(nextElementX, initialY + TextAlign),
-            Height = (int)(TextHeight*Constants.SpecialScaling),
-            Width = (int)(TextWidth*Constants.SpecialScaling),
+            Height = (int)(PreviewTextHeight*Constants.SpecialScaling),
+            Width = (int)(PreviewTextWidth*Constants.SpecialScaling),
             Text = ColorPreviewText,
             UseMnemonic = Constants.UseMnemonic,
         };
         
-        nextElementX += (int)((TextWidth + Constants.WidthMargin)*Constants.SpecialScaling);
+        nextElementX += (int)((PreviewTextWidth + Constants.WidthMargin)*Constants.SpecialScaling);
 
         _colorPreview = new PictureBox
         {
@@ -126,7 +146,7 @@ public class ColorPickerWrapper : WrapperBase, ILogicOptionObserver
 
         return new List<Control>
         {
-            _checkBox, _selectColorButton, _selectRandomColorButton, _useDefaultColorButton, _label, _colorPreview
+            _nameLabel, _checkBox, _selectColorButton, _selectRandomColorButton, _useDefaultColorButton, _previewLabel, _colorPreview
         };
     }
 


### PR DESCRIPTION
This changes the text on the buttons for color options and makes the buttons smaller. This gives enough room to fit the name of the option at the start of the row which was previously not visible.
Tooltips were added to explain what the checkbox and buttons do and to show the option description, and useless tooltips that simply repeated the visible text were removed.