### PR TITLE
Fixes Debugging in Rider

### DIFF
--- a/Build Tools/Build Releases.ps1
+++ b/Build Tools/Build Releases.ps1
@@ -1,17 +1,17 @@
-﻿$outputPath = Read-Host "Please enter the path to output builds to: "
+﻿$outputPath = Read-Host "Please enter the path to output builds to"
 
 cd ..\MinishCapRandomizerUI
-dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-x64\ -r win-x64
-dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-x86\ -r win-x86
-dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-arm64\ -r win-arm64
+dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-x64\ -r win-x64 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-x86\ -r win-x86 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerUI.csproj -c Release -o $outputPath\UI\win-arm64\ -r win-arm64 -p:PublishSingleFile=true
 cd ..\MinishCapRandomizerCLI
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-x64\ -r win-x64
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-x86\ -r win-x86
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-arm64\ -r win-arm64
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-arm\ -r win-arm
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-x64\ -r linux-x64
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-arm64\ -r linux-arm64
-dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-arm\ -r linux-arm
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-x64\ -r win-x64 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-x86\ -r win-x86 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-arm64\ -r win-arm64 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\win-arm\ -r win-arm -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-x64\ -r linux-x64 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-arm64\ -r linux-arm64 -p:PublishSingleFile=true
+dotnet publish .\MinishCapRandomizerCLI.csproj -c Release -o $outputPath\CLI\linux-arm\ -r linux-arm -p:PublishSingleFile=true
 cd '..\Build Tools\' 
 Write-Host "Done Building!" -foregroundcolor Green
 pause

--- a/MinishCapRandomizerCLI/MinishCapRandomizerCLI.csproj
+++ b/MinishCapRandomizerCLI/MinishCapRandomizerCLI.csproj
@@ -7,7 +7,6 @@
         <Nullable>enable</Nullable>
         <StartupObject>MinishCapRandomizerCLI.Program</StartupObject>
         <ApplicationIcon>icon.ico</ApplicationIcon>
-        <PublishSingleFile>true</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <SelfContained>true</SelfContained>
         <NoWin32Manifest>true</NoWin32Manifest>
@@ -16,7 +15,7 @@
 		<Title>Minish Cap Randomizer CLI</Title>
 		<Description>A CLI that wraps the Legend of Zelda Minish Cap Randomizer Core</Description>
 		<Product>Minish Cap Randomizer CLI</Product>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+        <Version>1.0.0-rc1.1</Version>
 		<LangVersion>default</LangVersion>
     </PropertyGroup>
 

--- a/MinishCapRandomizerUI/MinishCapRandomizerUI.csproj
+++ b/MinishCapRandomizerUI/MinishCapRandomizerUI.csproj
@@ -7,7 +7,6 @@
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <PublishSingleFile>true</PublishSingleFile>
         <PublishReadyToRun>true</PublishReadyToRun>
         <SelfContained>true</SelfContained>
         <StartupObject>MinishCapRandomizerUI.Program</StartupObject>
@@ -16,8 +15,7 @@
 		<Title>Minish Cap Randomizer UI</Title>
 		<Description>A GUI that wraps the Legend of Zelda Minish Cap Randomizer Core</Description>
 		<Product>Minish Cap Randomizer UI</Product>
-		<FileVersion>0.7.0</FileVersion>
-		<AssemblyVersion>0.7.0</AssemblyVersion>
+        <Version>1.0.0-rc1.1</Version>
 		<LangVersion>default</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
Rider's debugger does not support debugging single file apps, see the top of this page: https://www.jetbrains.com/help/rider/Debugging_Code.html

This change is purely a development change that removes the single file flag from the csproj of both the UI and CLI and moves that flag to the build scripts, meaning for local development you can once again use the Rider debugger.

No functional changes assuming you build release builds using the build script, which should support PS Core and thus be able to be ran on any reasonable modern operating system.