### PR TITLE
Fix edge case where ELEMENT_COUNT was undefined and was then referenced

### DIFF
--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -2541,10 +2541,11 @@
 	!endif
 	!ifdef - AD_ELEMENT_SPECIAL_CASE
 		!define - ELEMENT_DEF - 3
+    !else
+    	!undefine - GOTELEMENTS
+	    !define - GOTELEMENTS - , (+`ELEMENT_COUNT`, Items.WaterElement, Items.FireElement, Items.WindElement, Items.EarthElement)
 	!endif
 	!eventdefine - requirementElementsAmount - `ELEMENT_DEF`
-	!undefine - GOTELEMENTS
-	!define - GOTELEMENTS - , (+`ELEMENT_COUNT`, Items.WaterElement, Items.FireElement, Items.WindElement, Items.EarthElement)
 !endif
 
 !define - DHC_FIG -


### PR DESCRIPTION
This is an old obscure bug that we found while running a load test with this logic setting string: NlgClFj90TjBgjMIYcAAMEUAUAEEEIAAAYEEIAAAAIEEAAEAEEIYAAIMcAAIAEAEEQMEUAIAAEIAEEEEEMIIEIUIQBQe

Error message:         "Message": "!define - GOTELEMENTS - , (+ELEMENT_COUNT, Items.WaterElement, Items.FireElement, Items.WindElement, Items.EarthElement) has an invalid/undefined define!",

Image of error:
![image](https://github.com/user-attachments/assets/9d2e1aa7-4752-4274-8818-62f821428235)
