### PR TITLE
New setting for Gentari goal hint in Mystery

### DIFF
--- a/RandomizerCore/Resources/Patches/ROM Buildfile.event
+++ b/RandomizerCore/Resources/Patches/ROM Buildfile.event
@@ -254,8 +254,25 @@ WORD customRNG
 #include "hash.event"
 #include "traps.event"
 #include "removeFusions.event"
-#include "goalHint.event"
 #include "c/textSpeed.cevent"
+
+// Gentari can reveal the goal requirements
+#ifndef goalHintAlways
+	#ifndef goalHintNutOrElement
+		#ifndef goalHintNut
+			#ifndef goalHintElement
+				#ifndef goalHintNutAndElement
+					#ifndef goalHintNever
+						#define goalHintNever
+					#endif
+				#endif
+			#endif
+		#endif
+	#endif
+#endif
+#ifndef goalHintNever
+	#include "goalHint.event"
+#endif
 
 #ifdef heartLimited // extra hearts do not grant extra hp
 

--- a/RandomizerCore/Resources/Patches/goalHint.event
+++ b/RandomizerCore/Resources/Patches/goalHint.event
@@ -1,7 +1,38 @@
 PUSH
-ORG 0xC850 // Gentari script after Jabber Nut check
-BYTE 0x5A 0x08 0x34 0x11 // show text box
-BYTE 0x03 0x08 0x26 0x00 // skip some other commands
+ORG 0xC82E // Gentari script with vanilla Jabber Nut check, we use this to jump to our custom checks
+SHORT 0x0803 // always jump to below code instead of depending on Jabber Nut
+#ifdef goalHintAlways
+    SHORT showGoalTextBox-0xC830 // skip checks and jump straight to goal reveal
+#endif
+
+ORG 0xC850 // Gentari script after successful vanilla Jabber Nut check, we use this for our custom checks
+#ifdef goalHintElement
+    SHORT 0x0400 0x0400 0x0400 0x0400 // no operation
+#else
+    #ifdef goalHintNutOrElement
+        SHORT 0x080F 0x005B // check for Jabber Nut
+        SHORT 0x0804 showGoalTextBox-0xC856 // if Link has it, reveal goal
+    #else
+        SHORT 0x080F 0x005B // check for Jabber Nut
+        SHORT 0x0805 0xC832-0xC856 // if Link does not have it, no goal reveal (jump to 0xC832)
+    #endif
+#endif
+#ifndef goalHintNut
+    SHORT 0x080F 0x0040 // check for Earth Element
+    SHORT 0x0804 showGoalTextBox-0xC85E // if Link has it, reveal goal
+    SHORT 0x080F 0x0041 // check for Fire Element
+    SHORT 0x0804 showGoalTextBox-0xC866 // if Link has it, reveal goal
+    SHORT 0x080F 0x0042 // check for Water Element
+    SHORT 0x0804 showGoalTextBox-0xC86E // if Link has it, reveal goal
+    SHORT 0x080F 0x0043 // check for Wind Element
+    SHORT 0x0805 0xC832-(showGoalTextBox-2) // if Link does not have it, no goal reveal (jump to 0xC832)
+#else
+    SHORT 0x0803 showGoalTextBox-0xC85A // since Jabber Nut check was successful, reveal goal
+#endif
+
+ORG 0xC878
+showGoalTextBox:
+SHORT 0x085A 0x1134 // show text box with text defined below
 
 ORG 0x9CC270+0x34*4
 WORD goalTextEnglish-0x9CC270

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -240,6 +240,7 @@
 !flag - Gameplay - Setting - Extras - NO_KINSTONE_DROPS - Disable Kinstone Drops - Kinstone Pieces can no longer randomly drop.\nThey can also not be obtained through any other means than items in the random item pool. - true
 !flag - Gameplay - Setting - Extras - NO_SHELL_DROPS - Disable Shell Drops - Mysterious Shells can no longer randomly drop.\nThey can also not be obtained from beating Simon's Simulations multiple times. - true
 !dropdown - Gameplay - Setting - Improvements - BOOTS_L - Boots on L - Allows you to use the Pegasus Boots by pressing the L button, once obtained. - BOOTS_L_NORMAL - Disabled - BOOTS_L_OFF - 'Disabled': Boots can only be used when equipped on the A or B button. - Enabled - BOOTS_L_NORMAL - 'Enabled': Boots can also be used with the L button. - Enabled + Minish - BOOTS_L_MINISH - 'Enabled + Minish': Even as a Minish, Boots can be used with the L button.\nWarning: Dashing as a Minish has some unintended effects.
+!dropdown - Gameplay - Setting - Mystery - GOAL_HINT - Gentari Requirements Hint - Talking to Gentari (the elder in Minish Village) will reveal the requirements needed to beat the game (see 'Main Settings').\nOnly matters in Mystery when these settings are not yet known by the player. - GOAL_HINT_NUT_OR_ELEMENT - Always - GOAL_HINT_ALWAYS - 'Always': Gentari will always reveal the information. - Nut Or Element - GOAL_HINT_NUT_OR_ELEMENT - 'Nut Or Element': Information is revealed when the player has the Jabber Nut or at least one Element. - Jabber Nut - GOAL_HINT_NUT - 'Jabber Nut': Information is revealed when the player has the Jabber Nut. - Element - GOAL_HINT_ELEMENT - 'Element': Information is revealed when the player has at least one Element. - Nut And Element - GOAL_HINT_NUT_AND_ELEMENT - 'Nut And Element': Information is revealed when the player has both the Jabber Nut and at least one Element. - Never - GOAL_HINT_NEVER - 'Never': Gentari reveals no information.
 
 # Cosmetic settings
 !dropdown - Cosmetics - Cosmetic - Music & Sound Effects - MUSIC_SETTING - Music - - VANILLA_MUSIC - None - NO_MUSIC - 'None': Removes Background Music. - Vanilla - VANILLA_MUSIC - 'Vanilla': Plays the original game music. - Shuffled - MUSIC_RANDO - 'Shuffled': Shuffles the Music heard throughout the game. 
@@ -394,6 +395,7 @@
 !define - `THREE_HEART`
 !define - `DAMAGE_MULTI`
 !define - `BOOTS_L`
+!define - `GOAL_HINT`
 
 # Logic setting defines
 !ifdef - BARLOVFARM
@@ -857,6 +859,28 @@
 !ifdef - BOOTS_L_MINISH
 	!eventdefine - bootsOnL
 	!eventdefine - bootsMinish
+!endif
+
+!ifdef - GOAL_HINT_ALWAYS
+	!eventdefine - goalHintAlways
+!else
+	!ifdef - GOAL_HINT_NUT_OR_ELEMENT
+		!eventdefine - goalHintNutOrElement
+	!else
+		!ifdef - GOAL_HINT_NUT
+			!eventdefine - goalHintNut
+		!else
+			!ifdef - GOAL_HINT_ELEMENT
+				!eventdefine - goalHintElement
+			!else
+				!ifdef - GOAL_HINT_NUT_AND_ELEMENT
+					!eventdefine - goalHintNutAndElement
+				!else
+					!eventdefine - goalHintNever
+				!endif
+			!endif
+		!endif
+	!endif
 !endif
 
 !ifdef - OCARINA_SELECT


### PR DESCRIPTION
This adds a setting that determines if and when Gentari hints at the goal and requirements of the seed (like how many elements and swords are required). This is important when playing with unknown settings that have to be figured out while playing.

Previously, the Gentari hint was always unlocked by talking to him with the Jabber Nut.
The new default option is that the Jabber Nut is still enough to get the hint from him, but additionally, showing him an element also works. This is friendlier for seeds where the Nut shows up late in the seed (or not at all).
Several other options are also available, including always getting the hint from Gentari.

What the preferred option is depends on the weighset used and player's taste, so, based on feedback, I added a setting to decide the Gentari hint behavior.