### PR TITLE
New option to make the logic consider the Barlov gambling game

### DIFF
--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -158,6 +158,7 @@
 !flag - Logic Settings - Setting - Logic Rules - NO_LOGIC - No Logic - Items can go anywhere without regard to logic.\nLIKELY RESULTS IN UNBEATABLE SEEDS!
 !dropdown - Logic Settings - Setting - Logic Rules - ACCESSIBILITY - Reachable - Determines which items and locations are guaranteed to be reachable. - ACCESS_BEATABLE - All Locations - ACCESS_LOCATIONS - 'All Locations': All enabled locations are reachable. - All NonKeys - ACCESS_INVENTORY - 'All NonKeys': Like 'All Locations', except keys can lock themselves. - Only the Goal - ACCESS_BEATABLE - 'Only the Goal': Only the goal is guaranteed to be reachable. Some locations and items may be inaccessible. If DHC setting is set to 'Never Open' then the goal is the pedestal requirements, otherwise the goal is Defeat Vaati.
 !dropdown - Logic Settings - Setting - Logic Rules - GRABBABLE - Grab items from a distance - Items can be collected from a distance with either Gust Jar, Boomerang, or even a Sword Slash. - GRABBABLE - Not Allowed - NOT_GRABBABLE - 'Not Allowed': Items cannot be grabbed from a distance. - Allowed - GRABBABLE - 'Allowed': Items can be grabbed from a distance, but this will never be required by logic. - Require - GRABBABLE_LOGIC - 'Require': Items can be grabbed from a distance and logic can require grabbing them when they are obviously grabbable. - Require Hard - GRABBABLE_HARD - 'Require Hard': Items can be grabbed from a distance, and logic can require some very difficult Boomerang throws to be able to collect these items.\nMany of these involve throwing the Boomerang in an arc behind or to the side of the items before making Link run in the opposite direction to get the Boomerang to grab the item on the return journey to Link.
+!dropdown - Logic Settings - Setting - Logic Rules - GUARANTEED_BARLOV - Barlov farm Infinite Rupees - Low Difficulty:\nChanges the gambling game ran by Barlov in town so no matter what chest you pick you will always win. - BARLOVFARM - Disabled - NOBARLOVFARM - 'Disabled': The gambling game is not modified to always win. You will always require finding enough rupees in the item pool before you have to buy items. - Enabled - BARLOVFARM - 'Enabled': The Barlov game is modified to always win. You will always require finding enough rupees in the item pool before you have to buy items. - Required - REQUIREDBARLOVFARM - 'Required': The Barlov game is modified to always win. You may be required to farm rupees from the Barlov game to afford purchasing items.
 
 !dropdown - Logic Settings - Setting - Weapons - BOMBWEAPON - Bombs - Bombs can damage nearly every enemy, Bombs are never considered for Simon Simulations, and Golden Enemies. - NOBOMB - No - NOBOMB - 'No': Bombs are not considered as Weapons. - Yes - YESBOMB - 'Yes': Bombs are considered as weapons for most regular enemy fights. - Yes + Bosses - BOSSBOMB - 'Yes + Bosses': Bombs are considered as weapons for most enemy fights. Fighting Green/Blu Chu, Madderpillars and Darknuts require only 10 bomb bag. Gleerok, Mazaal and Scissor Beetles require at least 30 bomb bag. Octo and Gyorg cannot be defeated with bombs.
 !dropdown - Logic Settings - Setting - Weapons - BOWWEAPON - Bows - Bow can damage most enemies, many enemies are very resiliant to damage. Chu Bosses and Darknuts are Immune. - NOBOW - No - NOBOW - 'No': Bows are not considered as Weapons. - Yes - YESBOW - 'Yes': Bows are considered as weapons for most enemy fights. Bows are never considered for Chu Bossfights, Darknuts, Scissor Beetles, Madderpillar, Wizrobes, Simon Simulations, and Golden Enemies. - Yes + Bosses - BOSSBOW - 'Yes + Bosses': Bows are considered as weapons for most enemy fights, but can also be solely required to defeat Gleerok and Mazaal.
@@ -165,35 +166,33 @@
 !dropdown - Logic Settings - Setting - Weapons - LAMPWEAPON - Lantern - The lit Lantern can instantly kill wizrobes by walking through them. - NOLAMP - No - NOLAMP - 'No': Lantern is not considered as a Weapon. - Yes - YESLAMP - 'Yes': Lantern is considered as a weapon for fighting Wizrobes.
 
 !dropdown - Logic Settings - Setting - Require Tricks - MITTSMONEY_SETTING - Mole Mitts farm Infinite Rupees - Low Difficulty:\nA single spot outside of Link's house can be dug to find a 20 Rupee that respawns every time you leave link's house. - NOMITTSMONEY - No - NOMITTSMONEY - 'No': You will always require finding enough rupees in the item pool before you have to buy items. - Yes - MITTSMONEY - 'Yes': You may be required to farm rupees outside link's house to afford purchasing items if Mitts are acquired.
-!dropdown - Logic Settings - Setting - Require Tricks - GUARANTEED_BARLOV - Barlov farm Infinite Rupees - Low Difficulty:\nChanges the gambling game ran by Barlov in town so no matter what chest you pick you will always win. Does not current affect logic. - BARLOVFARM - No - NOBARLOVFARM - 'No': You will always require finding enough rupees in the item pool before you have to buy items. - Yes - BARLOVFARM - 'Yes': You will be required to farm rupees from the Barlov game in town to afford purchasing items.
-
 !dropdown - Logic Settings - Setting - Require Tricks - BLOWDUST_SETTING - Bombs blow away dust - Low Difficulty:\nDust piles can be found that can be blown away to what is underneath. - GUST - No - GUST - 'No': Gust Jar will always be required to blow away dust piles. - Yes - GUSTBOMBS - 'Yes': Bombs may be required to blow away dust piles instead of Gust Jar. 
+
 !dropdown - Logic Settings - Setting - Require Tricks - MUSHROOM_SETTING - Crenel mushroom grab with Gust jar - Low Difficulty:\nHalf way up Mt Crenel across the wooden bridge, the mushroom on the ledge above can be grabbed with the Gust Jar to continue climbing up the mountain.\nThis only matters when playing with 'OpenWorld' enabled, since reaching this area requires either Bombs or Grip ring. - NOMUSH - No - NOMUSH - 'No': You will always be expected to have Bombs or Grip Ring to continue up the mountain. - Yes - YESMUSH - 'Yes': You may be required to use the Gust Jar to grab the mushroom to continue up the mountain.
-
 !dropdown - Logic Settings - Setting - Require Tricks - ARROWBREAK_SETTING - Light Arrows break objects - Low Difficulty:\nFully charged Light Arrow shots can break pots, bushes, and small trees. - NOLIGHTS - No - NOLIGHTS - 'No': Light Arrows will never be required to break objects. - Yes - YESLIGHTS - 'Yes': Some obstacles may require Light Arrows to destroy.
+
 !dropdown - Logic Settings - Setting - Require Tricks - BOBOMBS_SETTING - Use Bobombs to destroy walls - Low Difficulty:\nBobombs can be used in 2 rooms in Cave of Flames, when a Bobomb is killed it explodes which can open Bomb Walls.\nItems such as Sword and Gust Jar can easily be used to move the Bobombs near the bomb wall to blow it up.\nOther items like the Boomerang, Shield, Bow, and even thrown pots can be used to make bobombs explode but with much higher difficulty, these will never be required due to it being mostly luck.\nIf you killed all the bobombs in a room without blowing up the wall, they will respawn after you do a QUICKWARP. - NOBOBOMBS - No - NOBOBOMBS - 'No': A Bomb Bag will always be required to destroy bombable walls. - Yes - YESBOBOMBS - 'Yes': Either a Sword, the Gust Jar, or a Bomb bag will be required to blow up bombable walls near Bobombs.
-
 !dropdown - Logic Settings - Setting - Require Tricks - LIKELIKE_SETTING - LikeLike cave without a Sword - Medium Difficulty:\nThe LikeLike digging cave in Minish Woods has 2 chests and has several LikeLikes that grab you when you try to open them. - NOLIKELIKE - No - NOLIKELIKE - 'No': A sword will always be required to reach these chests. - Yes - YESLIKELIKE - 'Yes': You may be required to collect these chests without a sword.
+
 !dropdown - Logic Settings - Setting - Require Tricks - GUARDSKIP_SETTING - Skip Town guard using Boots - High Difficulty:\nThe Guard found on the West side of Town blocks your path to Trilby Highlands and beyond, unless you have: a Sword+Spin, a Cape, or Flippers.\nIt is possible to dash with the boots faster than the guard and then quickly roll past them. - NOGUARDSKIP - No - NOGUARDSKIP - 'No': You will only be expected to get past the guard if the guard has moved out of the way because you have the required items. - Yes - YESGUARDSKIP - 'Yes': You may be required to reach Trilby Highlands and beyond by using just the boots.
-
 !dropdown - Logic Settings - Setting - Require Tricks - CRENELBEAM_SETTING - Use Beam to hit switch on Mt Crenel - Medium Difficulty:\nIn the section after the rain on Mt Crenel is a series of caves, one cave has a switch on the other side of a gap that needs to be hit to extend a bridge.\nThis switch can be hit with any of: Boomerang, Bomb Bag, Bow, Sword and Peril Beam, Sword and Sword Beam, or can be skipped entirely with the Rocs Cape. - NOBEAM - No - NOBEAM - 'No': The switch will never require being hit with a sword beam or peril beam. - Yes - YESBEAM - 'Yes': You may be required to hit the switch with a beam, if you have peril beam then you can damage down on the chuchu enemies nearby. If sword beam is required to hit the switch then a bottle will always be required as well (To store a fairy/potion so you can be on full HP to fire a beam).
+
 !dropdown - Logic Settings - Setting - Require Tricks - DTBEETLE_SETTING - Use DownThrust to flip Spikey Beetles - Low Difficulty:\nThe spikey beetles found in the entrance of Cave of Flames need to be flipped onto their back in order to be killed.\nThe actions that can do this are: Cane shot, Shield bonk, Bomb explosion, or Down Strike. - NOTHRUST - No - NOTHRUST - 'No': DownThrust will never be required to flip spikey beetles. - Yes - YESTHRUST - 'Yes': DownThrust may be required to flip spikey beetles.
-
 !dropdown - Logic Settings - Setting - Require Tricks - DARKROOMS_SETTING - Dark Rooms without a Lantern - Low/Medium Difficulty:\nVarious rooms in the game are dark which makes the room black except for a small circle around link at all times, if the Lantern is equipped then the light extends to a much larger circle. - NODARK - No - NODARK - 'No': Dark rooms will always require a Lantern in order to navigate. The only exception is a small section of a dark room lit by a lamp in Temple of Droplets after the lilypad section to reach the Blue Warp, as this is required in the vanilla game. - Yes - YESDARK - 'Yes': Dark rooms may require to be navigated without a lantern. In most setting combinations this is low difficulty, however if Open World is enabled then some sections of Temple of Droplets may require navigation in the dark that are much harder.
+
 !dropdown - Logic Settings - Setting - Require Tricks - EXTENDCAPE_SETTING - Tricky Cape jumps across water - Medium Difficulty:\nThe Cape can be used to make many unintended jumps across bodies of water you wouldn't expect. Some gaps seem too far to be reachable normally or require jumping at a weird angle, however the distance of the cape glide can be extended:\nInstead of holding the cape button the entire time, tap the cape to do a hop and then press and hold to glide after link is near the end of his hop. - NOEXTENSION - No - NOEXTENSION - 'No': Cape jumps across large bodies of water will always require the flippers. - Yes - YESEXTENSION - 'Yes': Cape can be required to make jumps across sections of water. The Cape jump to the moving platform in Palace is its own setting.
-
 !dropdown - Logic Settings - Setting - Require Tricks - LAKEMINISH_SETTING - Minish in Lake without Boots - Medium Difficulty:\nTurning Minish in lake normally requires using the boots to bonk into a tree near the cabin, however that is not the only way of turning minish in lake.\nIf Red Fusions are enabled then you can ocarina warp to lake to shrink at the stump located there instead, navigate through the path opened by the crack to reach the island in the middle of the lake where Librari can be found.\nFrom here you can then jump off the ledge into the middle of the lake. You can always regrow at the tree without having to bonk into it first so you will never be softlocked. - NOLAKEMINISH - No - NOLAKEMINISH - 'No': Minish Sized locations in lake will always require the boots to reach. - Yes - YESLAKEMINISH - 'Yes': Boots may not be required to reach lake minish if it is possible to reach Librari and you have the Flippers.
+
 !dropdown - Logic Settings - Setting - Require Tricks - CABINSWIM_SETTING - Swim to Cabin without lilypad - Low Difficulty:\nIn the Minish path located at the lake cabin, there is a lilypad you can use to reach the pier on the bottom side of the path. If you try and swim down to the pier you cannot climb up onto it from in the water,\nhowever you can instead swim to the screen transition at the bottom which will make you enter the cabin, you can then exit the doorway you came from to be placed on the pier. - NOCABIN - No - NOCABIN - 'No': Gust Jar will always be required to reach the lake cabin as minish. - Yes - YESCABIN - 'Yes': Either Gust Jar or Flippers can be required to reach the lake cabin as minish.
-
 !dropdown - Logic Settings - Setting - Require Tricks - CLOUDSKILL_SETTING - Kill Cloud Sharks without Weapons - Medium Difficulty:\nThe Cloud Shark enemies found in Cloud Tops can be killed with various damaging items like Sword, Bombs or Bow.\nHowever they can die if they jump off a ledge into the void, this can be easy to do by just standing still on the edge of the platform and waiting for them to jump attack you. - NOCLOUDSKILL - No - NOCLOUDSKILL - 'No': Cloud Sharks will always require a Weapon to kill, depending on what weapon settings are chosen. - Yes - YESCLOUDSKILL - 'Yes': Cloud Sharks can require no items to kill them, stand still by and edge and wait until they jump off to their deaths.
+
 !dropdown - Logic Settings - Setting - Require Tricks - POWJUMP_SETTING - PoW 2F is clearable without a Cane - High Difficulty:\nIn Palace of Winds 2F is a sequence of rooms that at the end requires the Cane of Pacci to hole jump up to a higher platform.\nHowever the majority of the floor can be skipped with a reasonably precise jump to a moving platform seen when first entering that floor at the bottom of the screen, this skips all the other rooms on this floor which never have any items.\nThe jump can be done either with a known setup to make it completely consistent, or the player can just attempt to jump and land on the platform when it stops moving. - NOPOWJUMP - No - NOPOWJUMP - 'No': Everything in Palace of Winds on the 2nd floor or later will require the Cane of Pacci to reach. - Yes - YESPOWJUMP - 'Yes': The only location in Palace of Winds that will require the Cane of Pacci to reach is the Pot Push Puzzle item drop.
-
 !dropdown - Logic Settings - Setting - Require Tricks - POWPOTOOL_SETTING - Pot Puzzle without Power Bracelets - Medium Difficulty:\nIn Palace of Winds 3F is a section you have to push some pots while minish to reach an item, these pots require the Power Bracelets to be pushed.\nOnce you regrow, you then must hit a switch which makes the item drop and a door open. This switch is reachable from a later part of the dungeon, which means the Power Bracelets can be avoided by reaching this later part of the dungeon, hitting the switch, and then backtracking back to the beginning. - NOPOWOOL - No - NOPOWOOL - 'No': Power Bracelets will always be required to reach this location. - Yes - YESPOWOOL - 'Yes': It may be required to reach 3F of the internal section of the dungeon during the 2nd half, located near the blue and red warps. Once the switch has been hit then you can return to the entrance of the dungeon and continue to the item location without having to shrink.
+
 !dropdown - Logic Settings - Setting - Require Tricks - DHCCANON_SETTING - DHC Canon rooms without Four Sword - High Difficulty:\nIn Dark Hyrule are two rooms that require knocking canon balls back at canons to complete a puzzle.\nThese two rooms are located near the main entrance of the dungeon, one on 1F found by heading north from the main entrance, the other found on B1 by going down the right staircase from the main entrance.\nThe intended method of completing these puzzles is by creating 4 Links with the Four Sword, and then doing a sword slash to knock all of the 4 canonballs back simultanously.\nHowever, it is possible (with setups and practice) to complete these without cloning but by instead using a well timed and placed bomb and sword slash.\nDespite this being a High Difficulty setting, it is unlikely to be required without Four Sword unless you play on the DHC: 'Always Open' setting. Having Four Sword as a requirement for entering DHC will make this always require Four Sword. - NODHCCANON - No - NODHCCANON - 'No': Four Sword (and a Spin) is always required to clear any canon room puzzle in DHC. - Yes - YESDHCCANON - 'Yes': DHC Canon rooms may require only a sword and a bomb bag.
-
 !dropdown - Logic Settings - Setting - Require Tricks - DHCJOSTLE_SETTING - DHC Pressure Pads without Four Sword - High Difficulty:\nAfter the 1F Canon room in the room with the moving blade trap, there are 4 pressure pads that must be pressed to spawn a chest containing an item.\nThe intended method to do this puzzle is to use the Four Sword and create 4 Links to stand on these pads simultanously, however it is possible to this with less clones.\nThese pads have a slight lag in their detection, which means you can use 2 Links (the amount you get with Red Sword) and make Link quickly walk between 2 pads adjacent to each other for the game to detect both as pressed,\nthe clone will mirror the main link and do the same on the other 2 switches to trigger all the pads simultanously and spawn the chest.\nSimilar to the DHC Canon setting, this is unlikely to be required unless you play on the DHC: 'Always Open' setting, and will always require Four Sword if one of the DHC requirements is Four Sword.\nThis trick is relatively low difficulty to execute, however to reach this area without the Four Sword you must pass a Canon room which will never be required unless the DHC Canon setting is set to 'Yes'. - NODHCJOSTLE - No - NODHCJOSTLE - 'No': Four Sword (and a Spin) will always be required for this location. - Yes - YESDHCJOSTLE - 'Yes': Red Sword (and a Spin) is all that is required for this location. If DHC Canon is set to 'No' then this location requires Four Sword (and a Spin).
-!dropdown - Logic Settings - Setting - Require Tricks - DHCSWITCHES_SETTING - DHC Switches without Four Sword - Medium/High Difficulty:\nIn Dark Hyrule Castle 2F are 2 rooms that contain puzzles which require hitting 4 switches simultanously to solve the puzzle,\nthese switches are close enough together at each location that a single spin attack from a precise spot can hit all the switches and solve the puzzle without having to create clones.\nHowever because they are located late in the dungeon behind puzzles that always require the Four Sword, this setting will only matter when playing Open World and going through the red warp to reach this floor. - NODHCSWITCHES - No - NODHCSWITCHES - 'No': Four Sword (and a Spin) will always be required to hit these switches. - Yes - YESDHCSWITCHES - 'Yes': A sword and spin is all that is needed to do these puzzles. If Open World is off then Four Sword (and Spin) are required.
 
+!dropdown - Logic Settings - Setting - Require Tricks - DHCSWITCHES_SETTING - DHC Switches without Four Sword - Medium/High Difficulty:\nIn Dark Hyrule Castle 2F are 2 rooms that contain puzzles which require hitting 4 switches simultanously to solve the puzzle,\nthese switches are close enough together at each location that a single spin attack from a precise spot can hit all the switches and solve the puzzle without having to create clones.\nHowever because they are located late in the dungeon behind puzzles that always require the Four Sword, this setting will only matter when playing Open World and going through the red warp to reach this floor. - NODHCSWITCHES - No - NODHCSWITCHES - 'No': Four Sword (and a Spin) will always be required to hit these switches. - Yes - YESDHCSWITCHES - 'Yes': A sword and spin is all that is needed to do these puzzles. If Open World is off then Four Sword (and Spin) are required.
 !dropdown - Logic Settings - Setting - Require Tricks - FOWPOT_SETTING - FoW Pot item early using the Gust Jar - Low Difficulty:\nIn Fortress of Winds there are 2 pots that contain items when playing with 'Special Pots', these are located in a dirt filled room in the back right section of the dungeon on 2F locked behind various locked doors.\nHowever the lower of the 2 pots can be grabbed with the Gust Jar from a much earlier part of the dungeon located in the front right section 2F.\nThe pot can accidentally be released inside the wall which makes the item unobtainable, simply reload the room and the pot and item will respawn. - NOFOWPOT - No - NOFOWPOT - 'No': From the entrance of Fortress, this location always requires at least 3 Fortress small keys as well as the Mole Mitts and Bow. - Yes - YESFOWPOT - 'Yes': From the entrance of Fortress, this location may only require the Gust Jar.
 
 !dropdown - Item Pool - Setting - Global - ITEM_POOL - Item Pool -  - ITEM_POOL_NORMAL - Reduced (RIP) - ITEM_POOL_RIP - 'Reduced': Removes many items from the pool:\nAll Heart Containers removed and some Heart Pieces removed (Max Hearts available is 10)\nRemote Bombs removed\nAll Spin Scroll Upgrades removed, a single Spin Scroll remains\nAll Butterflies removed\nAll Quivers removed\nA Shield is removed, a single Shield remains\nA Boomerang is removed, a single Boomerang remains. If either 'Vanilla Red Fusions' or 'Vanilla Green Fusions' are on then no Boomerangs are removed.\n3 Bottles removed, a single Bottle remains\n3 Bomb bags are removed, a single Bomb bag remains - Balanced - ITEM_POOL_NORMAL - 'Balanced': Normal Item Pool. - Plentiful - ITEM_POOL_PLENTIFUL - 'Plentiful': Adds extra copies of major items to the pool.\nItems with 2 extra copies:\nSword\nLantern\nGust Jar\nCane of Pacci\nRocs Cape\nOcarina\nFlippers\nSpin Attack\nItems with 1 extra copy:\nBow\nMole Mitts\nPegasus Boots\nGrip Ring\nGraveyard Key\nIf Gold Kinstones are randomized:\n2 extra Cloud Kinstones, 2 extra Swamp Kinstones, and an extra Falls Kinstone (5 extra if combined)\nIf other fusion colors are randomized:\n2 of each red shape (6 if combined)\n2 of each blue shape (4 if combined)\n3 of each green shape (9 if combined)\nIf Big Keysanity is on then there is an extra Big Key for each Dungeon\nIf Small Keysanity is on then there are 2 extra Small Keys for each Dungeon
@@ -345,12 +344,12 @@
 
 !define - `ACCESSIBILITY`
 !define - `GRABBABLE`
+!define - `GUARANTEED_BARLOV`
 !define - `BOMBWEAPON`
 !define - `BOWWEAPON`
 !define - `GUSTWEAPON`
 !define - `LAMPWEAPON`
 !define - `MITTSMONEY_SETTING`
-!define - `GUARANTEED_BARLOV`
 !define - `BLOWDUST_SETTING`
 !define - `MUSHROOM_SETTING`
 !define - `ARROWBREAK_SETTING`
@@ -396,7 +395,7 @@
 !define - `BOOTS_L`
 
 # Logic setting defines
-!ifdef - BARLOVFARM
+!ifndef - NOBARLOVFARM
 	!eventdefine - guaranteedBarlov
 !endif
 !ifdef - INSTANT_TEXT
@@ -447,37 +446,37 @@
 	!eventdefine - noFairy
 !endif
 !ifndef - GORON_ALT_PRICES
-	!define - GORONLEFT1 	-		(|(+4,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID1 	-		(|(+2,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT1 -		(|(+1,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT2 	-		(|(+10, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID2 	-		(|(+7,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT2 -		(|(+5,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT3 	- :2,	(|(+19, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID3	-		(|(+15, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT3 -		(|(+12, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT4 	- :2,	(|(+31, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID4 	- :2,	(|(+26, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT4 - :2,	(|(+22, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT5 	- :3,	(|(+46, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID5 	- :2,	(|(+40, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT5 - :2,	(|(+35, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
+	!define - GORONLEFT1 	-		(|(+4,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID1 	-		(|(+2,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT1 -		(|(+1,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT2 	-		(|(+10, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID2 	-		(|(+7,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT2 -		(|(+5,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT3 	- :2,	(|(+19, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID3	-		(|(+15, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT3 -		(|(+12, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT4 	- :2,	(|(+31, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID4 	- :2,	(|(+26, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT4 - :2,	(|(+22, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT5 	- :3,	(|(+46, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID5 	- :2,	(|(+40, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT5 - :2,	(|(+35, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
 !else
-	!define - GORONLEFT1 	-				(|(+6,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID1 	-	Items.Wallet,	(|(+3,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT1 - 				(|(+1,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT2 	- 				(|(+12, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID2 	-				(|(+9,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT2 -				(|(+7,  Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT3 	- ,				(|(+18, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID3	-				(|(+15, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT3 - 				(|(+13, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT4 	- ,				(|(+24, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID4 	- ,				(|(+21, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT4 - ,				(|(+19, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONLEFT5 	- ,				(|(+30, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONMID5 	- ,				(|(+27, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
-	!define - GORONRIGHT5 - ,				(|(+25, Items.Rupee100, Items.Rupee200:2), Helpers.MittsMoney)
+	!define - GORONLEFT1 	-				(|(+6,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID1 	-	Items.Wallet,	(|(+3,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT1 - 				(|(+1,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT2 	- 				(|(+12, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID2 	-				(|(+9,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT2 -				(|(+7,  Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT3 	- ,				(|(+18, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID3	-				(|(+15, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT3 - 				(|(+13, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT4 	- ,				(|(+24, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID4 	- ,				(|(+21, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT4 - ,				(|(+19, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONLEFT5 	- ,				(|(+30, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONMID5 	- ,				(|(+27, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
+	!define - GORONRIGHT5 - ,				(|(+25, Items.Rupee100, Items.Rupee200:2), Helpers.InfiniteMoney)
 	!eventdefine - goronJPPrices
 !endif
 !ifndef - NOT_GRABBABLE
@@ -3547,25 +3546,27 @@ HasGhiniDamage;		Helper;;	(|Helpers.HasSword `BOWHELPER` `BOMBHELPER` `GUSTHELPE
 	PoWDrop;				Helper;;	(|(&Items.RocsCape, (|Helpers.CanSplit3, Helpers.CanSplit4), Items.PacciCane, Helpers.PoWPotPuzzle), (&(|Helpers.PoW2ndHalf, Helpers.PoWBlueWarp), Helpers.DarkRooms, (|(&Helpers.PoW2ndHalf1stDoor, Items.RocsCape), Helpers.PoWShortcuts), (|Items.GustJar, Helpers.HasBoomerang)), (&Helpers.PoWRedWarp, Helpers.OverworldBlocks, (|Items.GustJar, Helpers.HasBoomerang)))
 	PoWHP;				Helper;;	(|(&Helpers.DarkRooms, (|(&Helpers.PoW2ndHalf1stDoor, Items.RocsCape), Helpers.PoWShortcuts), Helpers.PoWHandRoom, (|Helpers.PoW2ndHalf, Helpers.PoWBlueWarp)), (&Helpers.PoWRedWarp, Helpers.OverworldBlocks), (&(|Helpers.CanSplit3, Helpers.CanSplit4), Helpers.PoWJump, Helpers.PoW1stDoor, (|Items.GustJar, Helpers.HasBoomerang)))
 !endif
-!ifndef - MITTSMONEY
-	MittsMoney;			Helper;;	Helpers.Inaccessible
-	ShopSimon;			Helper;;	(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	Shop80;				Helper;;	(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	Shop300;				Helper;;	(+510, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	Shop600;				Helper;;	(+1110, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	ShopWitch;			Helper;;	(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	ShopScrubTrilby;		Helper;;	(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
-	ShopScrubCrenel;		Helper;;	(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
+!ifdef - REQUIREDBARLOVFARM
+	# Guarantee you can find at least 50 Rupees total in the item pool (or through Mole Mitts) before Barlov game is considered for logic (even though it only costs 10 Rupees)
+	!ifdef - MITTSMONEY
+		InfiniteMoney;			Helper;;	(|(+50, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
+	!else
+		InfiniteMoney;			Helper;;	(+50, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200)
+	!endif
 !else
-	MittsMoney;			Helper;;	Items.MoleMitts
-	ShopSimon;			Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	Shop80;				Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	Shop300;				Helper;;	(|(+510, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	Shop600;				Helper;;	(|(+1110, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	ShopWitch;			Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	ShopScrubTrilby;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
-	ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Items.MoleMitts)
+	!ifdef - MITTSMONEY
+		InfiniteMoney;			Helper;;	Items.MoleMitts
+	!else
+		InfiniteMoney;			Helper;;	Helpers.Inaccessible
+	!endif
 !endif
+ShopSimon;			Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+Shop80;				Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+Shop300;				Helper;;	(|(+510, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+Shop600;				Helper;;	(|(+1110, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+ShopWitch;			Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+ShopScrubTrilby;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
+ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:20, Items.Rupee50:50, Items.Rupee100:100, Items.Rupee200:200), Helpers.InfiniteMoney)
 !ifdef - NOGUARDSKIP
 	GuardSkip;				Helper;;	Helpers.Inaccessible
 !else


### PR DESCRIPTION
The option for making the Barlov minigame a guaranteed win never affected logic previously. This pull request adds an option to make the logic expect you to make use of this patch.
The setting is also moved to the "Logic Rules" section since I feel it fits better there. The description has been updated to clarify which option affects logic.