### PR TITLE
New possibilities for dungeon prizes

### DIFF
--- a/RandomizerCore/Randomizer/Logic/Imports/LogicImports.cs
+++ b/RandomizerCore/Randomizer/Logic/Imports/LogicImports.cs
@@ -49,7 +49,7 @@ public static class LogicImports
 
         if (prizeDungeonForItem == null) return true;
 
-        var accessible = prizeDungeonForItem.Contents is
+        var accessible = prizeDungeonForItem.AssociatedPrize is
         {
             Type: ItemType.EarthElement or ItemType.FireElement or ItemType.WaterElement or ItemType.WindElement
         } || (itemToPlace.ShufflePool is ItemPool.DungeonMajor && DependencyBase.BeatVaatiDependency!.DependencyFulfilled());
@@ -70,7 +70,7 @@ public static class LogicImports
 
         if (prizeDungeonForItem == null) return true;
 
-        var accessible = prizeDungeonForItem.Contents is
+        var accessible = prizeDungeonForItem.AssociatedPrize is
         {
             Type: ItemType.EarthElement or ItemType.FireElement or ItemType.WaterElement or ItemType.WindElement
         } || DependencyBase.BeatVaatiDependency!.DependencyFulfilled();

--- a/RandomizerCore/Randomizer/Logic/Location/Location.cs
+++ b/RandomizerCore/Randomizer/Logic/Location/Location.cs
@@ -57,6 +57,7 @@ public class Location
     public static List<Func<Location, Item, List<Location>, bool>> ShufflerConstraints { get; } = new();
 
     public Item? Contents { get; private set; }
+    public Item? AssociatedPrize { get; set; }
     public int RecursionCount { get; private set; }
 
     public static List<Item> GetItems(List<Location> locations)
@@ -115,10 +116,10 @@ public class Location
     ///     Check if an item can be placed into the location
     /// </summary>
     /// <param name="itemToPlace">The item to check placeability of</param>
-    /// <param name="availableItems">The items used for checking accessibility</param>
-    /// <param name="locations">The locations used for checking accessibility</param>
+    /// <param name="allLocations">The locations used for checking accessibility</param>
+    /// <param name="ignoreConstraints">Whether the checks in the ShufflerConstraints should be skipped</param>
     /// <returns>If the item can be placed in this location</returns>
-    public bool CanPlace(Item itemToPlace, List<Location> allLocations)
+    public bool CanPlace(Item itemToPlace, List<Location> allLocations, bool ignoreConstraints = false)
     {
         if (ShufflerConstraints.Any() &&
             !ShufflerConstraints.Contains(Imports.LogicImports.FunctionValues["VERIFY_LOCATION_IS_ACCESSIBLE"]))
@@ -142,7 +143,7 @@ public class Location
 
         if (itemToPlace.ShufflePool is ItemPool.DungeonPrize && Type != LocationType.DungeonPrize) return false;
 
-        return ShufflerConstraints.All(constraint => constraint.Invoke(this, itemToPlace, allLocations));
+        return ignoreConstraints || ShufflerConstraints.All(constraint => constraint.Invoke(this, itemToPlace, allLocations));
     }
 
     public bool IsAccessible(Item? itemToPlace = null)

--- a/RandomizerCore/Randomizer/Models/Item.cs
+++ b/RandomizerCore/Randomizer/Models/Item.cs
@@ -6,13 +6,13 @@ using RandomizerCore.Utilities.Util;
 
 namespace RandomizerCore.Randomizer.Models;
 
-public readonly struct Item
+public struct Item
 {
     public readonly ItemType Type;
     public readonly KinstoneType Kinstone;
-    public readonly ItemPool ShufflePool;
+    public ItemPool ShufflePool;
     public readonly byte SubValue;
-    public readonly string Dungeon;
+    public string Dungeon;
     public readonly bool UseAny;
     private readonly List<DependencyBase> Dependencies;
 

--- a/RandomizerCore/Randomizer/Parser/DirectiveParser.cs
+++ b/RandomizerCore/Randomizer/Parser/DirectiveParser.cs
@@ -31,6 +31,7 @@ public class DirectiveParser
     public string? LogicVersion;
     public readonly List<LogicOptionBase> Options;
     public readonly Dictionary<Item, ChanceItemSet> Replacements;
+    public readonly Dictionary<string, string> PrizePlacements;
     public uint? RomCrc;
 
     public DirectiveParser()
@@ -40,6 +41,7 @@ public class DirectiveParser
         EventDefines = new List<EventDefine>();
         LocationTypeOverrides = new Dictionary<Item, LocationType>();
         Replacements = new Dictionary<Item, ChanceItemSet>(new ItemComparerIgnorePool());
+        PrizePlacements = new Dictionary<string, string>();
         _amountReplacementReferences = new List<ItemAmountSet>();
         _amountReplacementsTemplate = new Dictionary<Item, List<int>>();
         _incrementalReplacementReferences = new List<ItemAmountSet>();
@@ -92,6 +94,7 @@ public class DirectiveParser
             case "!replaceincrement":
             case "!settype":
             case "!import":
+            case "!prizeplacement":
                 return false;
             default:
                 throw new ParserException($"\"{directive}\" is not a valid directive! The logic file may be bad.");
@@ -158,6 +161,9 @@ public class DirectiveParser
                     break;
                 case "!import":
                     ParseImportDirective(mainDirectiveParts);
+                    break;
+                case "!prizeplacement":
+                    ParsePrizePlacementDirective(mainDirectiveParts);
                     break;
                 case "!name":
                     LogicName = mainDirectiveParts[1];
@@ -345,6 +351,11 @@ public class DirectiveParser
         _amountReplacementsTemplate.Clear();
     }
 
+    public void ClearPrizePlacements()
+    {
+        PrizePlacements.Clear();
+    }
+
     public void DuplicateAmountReplacements()
     {
         AmountReplacements = new Dictionary<Item, List<ItemAmountSet>>(new ItemComparerIgnorePool());
@@ -418,6 +429,17 @@ public class DirectiveParser
             throw new ParserException("Import directive requires a function that does not exist!");
 
         Location.ShufflerConstraints.Add(function);
+    }
+
+    public void ParsePrizePlacementDirective(string[] directiveParts)
+    {
+        if (directiveParts.Length != 3)
+            throw new ParserException("Prize placement directive does not have the required number of parameters!");
+
+        var locationName = directiveParts[1];
+        var dungeonName = directiveParts[2];
+
+        PrizePlacements.Add(locationName, dungeonName);
     }
 
     private LogicDefine ParseDefineDirective(string[] directiveParts)

--- a/RandomizerCore/Randomizer/Parser/Parser.cs
+++ b/RandomizerCore/Randomizer/Parser/Parser.cs
@@ -228,7 +228,7 @@ public class Parser
 
         var dungeon = "";
 
-        if (itemShufflePool is ItemPool.DungeonMajor && allItemParts.Length < 3)
+        if (itemShufflePool is ItemPool.DungeonMajor or ItemPool.DungeonMinor && allItemParts.Length < 3)
             throw new ParserException("Dungeon item is missing dungeon name!");
 
         if (allItemParts.Length >= 3)

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -7097,6 +7097,25 @@ Inaccessible;    Helper;; Items.Untyped.0xFF:0xFF  # ask for 255 of them for goo
 		!endif
 	!endif
 !endif
+# Unrequired or Barren Cave of Flames should also affect locations from Fusions that are locked behind it
+!ifdef - VANILLA_RED_FUSIONS
+	!define - COFREDFUSION - :CoF
+!else
+	!ifdef - COMBINED_RED_FUSIONS
+		!define - COFREDFUSION - :CoF
+	!else
+		!define - COFREDFUSION -
+	!endif
+!endif
+!ifdef - VANILLA_GREEN_FUSIONS
+	!define - COFGREENFUSION - :CoF
+!else
+	!ifdef - COMBINED_GREEN_FUSIONS
+		!define - COFGREENFUSION - :CoF
+	!else
+		!define - COFGREENFUSION -
+	!endif
+!endif
 
 # Junk fill for Barren DHC
 !ifndef - NODHC
@@ -7717,7 +7736,7 @@ CrenelBase_WaterCave_HP;			`HP`;				0x0FB32B;														(|(&Helpers.AccessTri
 CrenelBase_MinishVineHole_Chest;	Any;					0x35-0x00-0x00;													(|(&Helpers.AccessTrilby, Helpers.LowerBean, (|Helpers.BombWalls, Items.RocsCape), Helpers.CrenelDust), (&Helpers.CrenelWindCrest, (|Helpers.UpperBean, (&Items.GripRing, (|Helpers.BombWalls, Items.RocsCape))), Helpers.CrenelDust), Helpers.Hundo);															Items.Kinstone.BlueL
 CrenelBase_MinishCrack_Chest;		Any;					0x27-0x03-0x00;													(|(&Helpers.AccessTrilby, Helpers.LowerBean, (|Helpers.BombWalls, Items.RocsCape), Helpers.CrenelDust), (&Helpers.CrenelWindCrest, (|Helpers.UpperBean, (&Items.GripRing, (|Helpers.BombWalls, Items.RocsCape))), Helpers.CrenelDust), Helpers.Hundo);															Items.Kinstone.RedV
 
-Crenel_VineTop_GoldenTektite		`GREENFUSIONENEMY`;	golden2Item:Define:FirstByte, golden2Sub:Define:SecondByte; 			(|(&Helpers.MinesMinishKitchenFusion,Helpers.AccessCrenel, Helpers.HasSword), Helpers.Hundo);																						Items.Rupee100
+Crenel_VineTop_GoldenTektite		`COFGREENFUSION``GREENFUSIONENEMY`;	golden2Item:Define:FirstByte, golden2Sub:Define:SecondByte;	(|(&Helpers.MinesMinishKitchenFusion,Helpers.AccessCrenel, Helpers.HasSword), Helpers.Hundo);																						Items.Rupee100
 Crenel_BridgeCave_Chest;			Any;					0x26-0x07-0x00;													(|(&Helpers.AccessCrenel, Helpers.BombWalls), Helpers.Hundo);																													Items.Kinstone.BlueL
 Crenel_FairyCave_HP;				`HP`;				0x0FB0BB;														(|(&Helpers.AccessCrenel, Helpers.BombWalls), Helpers.Hundo);																													Items.PieceOfHeart
 Crenel_BelowCoF_GoldenTektite		`REDFUSIONENEMY`;		golden7Item:Define:FirstByte, golden7Sub:Define:SecondByte;			(|(&Helpers.Tingle2Fusion, Helpers.AccessCrenel, Helpers.HasSword, (|Items.GripRing, Items.BombBag, Helpers.CrenelMushroom, Helpers.CrenelWindCrest)), Helpers.Hundo);						Items.Rupee200
@@ -7729,15 +7748,15 @@ Crenel_Dojo_NPC:dojo;				`DOJOITEM`;			graybladeDojoItem:Define:FirstByte, grayb
 Crenel_GreatFairy_NPC;				Any;					0x00B828;														(|(&Helpers.AccessCrenel, Items.GripRing, Helpers.BombWalls, (|Items.BombBag, Helpers.HasBottle)), Helpers.Hundo);																	Items.BombBag
 Crenel_ClimbFusion_Chest;			`GREENFUSION`;		0x0FE10E;														(|(&Helpers.MeenieFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Kinstone.BlueL
 Crenel_DigCave_HP;				`HP`;				0x0F3BA7;														(|(&Helpers.AccessCrenel, Items.GripRing, Items.MoleMitts), Helpers.Hundo);																										Items.PieceOfHeart
-Crenel_BeanstalkFusion_HP;			`REDFUSIONHP`;		0x0F5D9B;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.PieceOfHeart
-Crenel_BeanstalkFusion_Item1		`REDFUSIONRUPEE`;		0x0F5DAB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item2		`REDFUSIONRUPEE`;		0x0F5DBB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item3		`REDFUSIONRUPEE`;		0x0F5DCB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item4		`REDFUSIONRUPEE`;		0x0F5DDB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item5		`REDFUSIONRUPEE`;		0x0F5DEB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item6		`REDFUSIONRUPEE`;		0x0F5DFB;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item7		`REDFUSIONRUPEE`;		0x0F5E0B;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
-Crenel_BeanstalkFusion_Item8		`REDFUSIONRUPEE`;		0x0F5E1B;														(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_HP			`COFREDFUSION`;	`REDFUSIONHP`;	0x0F5D9B;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.PieceOfHeart
+Crenel_BeanstalkFusion_Item1		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DAB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item2		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DBB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item3		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DCB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item4		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DDB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item5		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DEB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item6		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5DFB;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item7		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5E0B;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
+Crenel_BeanstalkFusion_Item8		`COFREDFUSION``REDFUSIONRUPEE`;	0x0F5E1B;											(|(&Helpers.MelariFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																									Items.Rupee20
 Crenel_RainPathFusion_Chest;		`GREENFUSION`;		0x0FE066;														(|(&Helpers.MinesMinishBedroomFusion, Helpers.AccessCrenel, Items.GripRing), Helpers.Hundo);																						Items.Kinstone.BlueL
 
 AccessMelari;										Helper;				;													(|Helpers.CrenelWindCrest, (&Helpers.AccessCrenel, (|(&Items.PacciCane, (|Items.GripRing, Helpers.CrenelMushroom)), (&Items.GripRing, (|Items.RocsCape, Helpers.LightArrowBreak, Items.GustJar), Helpers.CrenelSwitch))))

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -99,8 +99,8 @@
 !dropdown - Main Settings - Setting - Dungeon Settings - COMPASS_SETTING - Compasses - Compasses - COMPASS_STANDARD - Start With - COMPASS_KEASY - 'Start With': Compasses are given to you from the start. - Vanilla - COMPASS_VANILLA - 'Vanilla': Compasses are in the same places they appear in the vanilla game. - Own Dungeon - COMPASS_STANDARD - 'Own Dungeon': Compasses are randomized to locations in the dungeon they are used in. - Own Region - COMPASS_REGION - 'Own Region': Compasses are randomized inside and in the vicinity of their own dungeon. - Any Dungeon - COMPASS_DUNGEON - 'Any Dungeon': Compasses are randomized inside all dungeons. - Any Region - COMPASS_REGDUN - 'Any Region': Compasses are randomized inside and in the vicinity of all dungeons. - Anywhere (Keysanity) - COMPASS_KEYSANITY - 'Anywhere': Compasses are randomized to any location in the world.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
 !dropdown - Main Settings - Setting - Dungeon Settings - SMALL_KEYS_SETTING - Small Keys - Small Keys - SMALL_KEYS_STANDARD - Removed (Keasy) - SMALL_KEASY - 'Removed': Small keys are removed, All small locked doors are open from the start. - Vanilla - SMALL_KEYS_VANILLA - 'Vanilla': Small keys are in the same places they appear in the vanilla game. - Own Dungeon - SMALL_KEYS_STANDARD - 'Own Dungeon': Small keys are randomized to locations in the dungeon they are used in. - Own Region - SMALL_KEYS_REGION - 'Own Region': Small keys are randomized inside and in the vicinity of their own dungeon. - Any Dungeon - SMALL_KEYS_DUNGEON - 'Any Dungeon': Small keys are randomized inside all dungeons. - Any Region - SMALL_KEYS_REGDUN - 'Any Region': Small keys are randomized inside and in the vicinity of all dungeons. - Anywhere (Keysanity) - SMALL_KEYSANITY - 'Anywhere': Small keys are randomized to any location in the world, expect to return to dungeons multiple times.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
 !dropdown - Main Settings - Setting - Dungeon Settings - BIG_KEYS_SETTING - Big Keys - Big Keys - BIG_KEYS_STANDARD - Removed (Keasy) - BIG_KEASY - 'Removed': Big keys are removed, All locked Boss doors are open from the start. - Vanilla - BIG_KEYS_VANILLA - 'Vanilla': Big keys are in the same places they appear in the vanilla game. - Own Dungeon - BIG_KEYS_STANDARD - 'Own Dungeon': Big keys are randomized to locations in the dungeon they are used in. - Own Region - BIG_KEYS_REGION - 'Own Region': Big keys are randomized inside and in the vicinity of their own dungeon. - Any Dungeon - BIG_KEYS_DUNGEON - 'Any Dungeon': Big keys are randomized inside all dungeons. - Any Region - BIG_KEYS_REGDUN - 'Any Region': Big keys are randomized inside and in the vicinity of all dungeons. - Anywhere (Keysanity) - BIG_KEYSANITY  - 'Anywhere': Big keys are randomized to any location in the world, expect to return to dungeons multiple times.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
-!dropdown - Main Settings - Setting - Dungeon Settings - SHUFFLE_ELEMENTS - Shuffle Elements - Shuffle Elements - SHUFFLE_ELEMENTS_OFF - Vanilla - SHUFFLE_ELEMENTS_VANILLA - 'Vanilla': The Elements are found in their vanilla locations. Will shuffle dungeon rewards if all 4 elements are required to complete the seed but the vanilla location is not accessible. - Dungeon Rewards - SHUFFLE_ELEMENTS_OFF - 'Dungeon Rewards': Elements are shuffled among the 6 Dungeon Rewards. - Anywhere - SHUFFLE_ELEMENTS_ON - 'Anywhere': Elements are shuffled anywhere in the world. The Element icons on the map are removed.
-!dropdown - Main Settings - Setting - Dungeon Settings - DUNGEON - NonElement Dungeons - NonElement Dungeons, This setting is disabled when 'Shuffle Elements' is set to 'Anywhere' or when 'Dungeons Required' is set to '5' or '6'. - NONE - Standard - NONE - 'Standard': NonElement Dungeons have no special rules. - Unrequired - UNREQ - 'Unrequired': NonElement Dungeons do not have items required to beat the game. - Barren - BARREN - 'Barren': NonElement Dungeons only contain junk items. - Regions Unrequired - UNREQSUR - 'Regions Unrequired': NonElement Dungeons and their Regions do not contain items needed to beat the game. - Regions Barren - BARRENSUR - 'Regions Barren': NonElement Dungeons and their Regions only contain junk items. \n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.
+!dropdown - Main Settings - Setting - Dungeon Settings - SHUFFLE_ELEMENTS - Shuffle Elements - Shuffle Elements - SHUFFLE_ELEMENTS_OFF - Vanilla - SHUFFLE_ELEMENTS_VANILLA - 'Vanilla': The Elements are found in their vanilla locations. Will shuffle dungeon rewards if all 4 elements are required to complete the seed but the vanilla location is not accessible. - Dungeon Rewards - SHUFFLE_ELEMENTS_OFF - 'Dungeon Rewards': Elements are shuffled among the 6 Dungeon Rewards. - Own Dungeon - SHUFFLE_ELEMENTS_DUNGEON - 'Own Dungeon': Elements are shuffled among the 6 Dungeons that have a Reward at the end, but are then placed in a random location within that Dungeon. - Own Region - SHUFFLE_ELEMENTS_REGION - 'Own Region': Elements are shuffled among the 6 Dungeons that have a Reward at the end, but are then placed in a random location inside or in the vicinity of that Dungeon. - Any Dungeon - SHUFFLE_ELEMENTS_ON_DUNGEONS - 'Any Dungeon': Elements are freely shuffled across all locations in all 7 Dungeons. The Element icons on the map are removed. - Any Region - SHUFFLE_ELEMENTS_ON_REGIONS - 'Any Region': Elements are freely shuffled inside and in the vicinity of all 7 Dungeons. The Element icons on the map are removed. - Anywhere - SHUFFLE_ELEMENTS_ON - 'Anywhere': Elements are shuffled anywhere in the world. The Element icons on the map are removed.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
+!dropdown - Main Settings - Setting - Dungeon Settings - DUNGEON - NonElement Dungeons - NonElement Dungeons, This setting is disabled when 'Shuffle Elements' is set to 'Any Dungeon', 'Any Region' or 'Anywhere' or when 'Dungeons Required' is set to '5' or '6'. - NONE - Standard - NONE - 'Standard': NonElement Dungeons have no special rules. - Unrequired - UNREQ - 'Unrequired': NonElement Dungeons do not have items required to beat the game. - Barren - BARREN - 'Barren': NonElement Dungeons only contain junk items. - Regions Unrequired - UNREQSUR - 'Regions Unrequired': NonElement Dungeons and their Regions do not contain items needed to beat the game. - Regions Barren - BARRENSUR - 'Regions Barren': NonElement Dungeons and their Regions only contain junk items. \n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.
 
 !dropdown - Main Settings - Setting - Requirements - DHC_SETTING - Dark Hyrule Castle Opens - Dark Hyrule Castle is the last dungeon in the game, it has the final boss Vaati. - OPENDHC - Never Open - NODHC - 'Never Open': A barrier is placed at the front of the dungeon, The game ends when you visit the sanctuary after completing all the requirements. - After Requirements - NORMALDHC - 'After Requirements': A barrier is placed at the front of the dungeon, This barrier is removed when you visit the sanctuary after completing ALL the requirements. The game ends when you defeat Vaati. - Always Open - OPENDHC - 'Always Open': There is no barrier at the front of the dungeon, the game ends when you defeat Vaati.
 !dropdown - Main Settings - Setting - Requirements - REQUIREMENT_ITEM - Requirement Reward - An item that the player receives once they meet the selected requirements. - REQUIREMENT_ITEM_DHC_BK - Disabled - REQUIREMENT_ITEM_NONE - 'Disabled': No extra item is awarded for requirement completion. - DHC Big Key - REQUIREMENT_ITEM_DHC_BK - 'DHC Big Key': The DHC Big Key is instantly awarded to the player once they meet the selected requirements. Overrides whatever the general Big Key setting is. - Random Item - REQUIREMENT_ITEM_RANDOM - 'Random Item': An item from the random item pool is instantly awarded to the player once they meet the selected requirements.
@@ -556,6 +556,14 @@
 	!eventdefine - vanillaShopOrder
 !endif
 
+!ifndef - SHUFFLE_ELEMENTS_ON_DUNGEONS
+	!ifndef - SHUFFLE_ELEMENTS_ON_REGIONS
+		!ifndef - SHUFFLE_ELEMENTS_ON
+			!define - ELEMENTS_TIED_TO_DUNGEONS
+		!endif
+	!endif
+!endif
+
 !ifdef - DOJOVANILLA
 	!ifdef - YES_SCROLL_PROG
 		!undefine - YES_SCROLL_PROG
@@ -602,7 +610,7 @@
 !endif
 !ifdef - AD_PED_3
 	!ifdef - 4ELEMENT
-		!ifdef - SHUFFLE_ELEMENTS_ON
+		!ifndef - ELEMENTS_TIED_TO_DUNGEONS
 			!define - AD_PED_NUM - 3
 		!else
 			!undefine - AD_PED_3
@@ -1576,7 +1584,7 @@
 			!endif
 			
 			!ifdef - AD_PED_4
-				!ifndef - SHUFFLE_ELEMENTS_ON
+				!ifdef - ELEMENTS_TIED_TO_DUNGEONS
 					!undefine - `DUNGEON`
 					!define - NONE
 				!endif
@@ -1642,7 +1650,7 @@
 		Items.Entrance.0x03;	DungeonEntrance;
 		!define - FOW_DUNGEONENTRANCE - :DHCValid;	DungeonEntrance
 	!else
-		!ifdef - SHUFFLE_ELEMENTS_ON
+		!ifndef - ELEMENTS_TIED_TO_DUNGEONS
 			!define - FOW_DUNGEONENTRANCE - :NoSpoiler:NoElement;	DungeonEntrance
 			Items.Entrance.0x03;	DungeonEntrance;
 		!else
@@ -1674,7 +1682,7 @@
 		Items.Entrance.0x05;	DungeonEntrance;
 		!define - POW_DUNGEONENTRANCE - :DHCValid;	DungeonEntrance
 	!else
-		!ifdef - SHUFFLE_ELEMENTS_ON
+		!ifndef - ELEMENTS_TIED_TO_DUNGEONS
 			!define - POW_DUNGEONENTRANCE - :NoSpoiler:NoElement;	DungeonEntrance
 			Items.Entrance.0x05;	DungeonEntrance;
 		!else
@@ -1715,8 +1723,8 @@
 !endif
 
 # Shuffle Elements removes the "Prize" dungeon and changes all the elements to regular "Major" items to be globally shuffled
-!ifdef - SHUFFLE_ELEMENTS_ON
-    !eventdefine - globalElements - 1   # if defined, does not draw elements on map (during full shuffle)
+!ifndef - ELEMENTS_TIED_TO_DUNGEONS
+    !eventdefine - globalElements # if defined, does not draw elements on map (during full shuffle)
 	!eventdefine - elementTraps
 	!undefine - `DUNGEON`
 	!define - NONE
@@ -2391,19 +2399,48 @@
 		Items.CarlovMedal;	Minor;
 	!endif
 !endif
-	!ifndef - SHUFFLE_ELEMENTS_VANILLA
-		!ifdef - SHUFFLE_ELEMENTS_ON
-			Items.EarthElement;		Major;
-			Items.FireElement;		Major;
-			Items.WaterElement;		Major;
-			Items.WindElement;		Major;
-		!else
-			Items.EarthElement;		DungeonPrize;
-			Items.FireElement;		DungeonPrize;
-			Items.WaterElement;		DungeonPrize;
-			Items.WindElement;		DungeonPrize;
+!ifndef - SHUFFLE_ELEMENTS_VANILLA
+	!ifdef - ELEMENTS_TIED_TO_DUNGEONS
+		Items.EarthElement;		DungeonPrize;
+		Items.FireElement;		DungeonPrize;
+		Items.WaterElement;		DungeonPrize;
+		Items.WindElement;		DungeonPrize;
+		!ifdef - SHUFFLE_ELEMENTS_DUNGEON
+			!prizeplacement - Deepwood_Prize - DWSPrize
+			!prizeplacement - CoF_Prize - CoFPrize
+			!prizeplacement - Fortress_Prize - FoWPrize
+			!prizeplacement - Droplets_Prize - ToDPrize
+			!prizeplacement - Crypt_Prize - RCPrize
+			!prizeplacement - Palace_Prize - PoWPrize
+		!endif
+		!ifdef - SHUFFLE_ELEMENTS_REGION
+			!prizeplacement - Deepwood_Prize - DWSPrizeOutside
+			!prizeplacement - CoF_Prize - CoFPrizeOutside
+			!prizeplacement - Fortress_Prize - FoWPrizeOutside
+			!prizeplacement - Droplets_Prize - ToDPrize
+			!prizeplacement - Crypt_Prize - RCPrizeOutside
+			!prizeplacement - Palace_Prize - PoWPrizeOutside
 		!endif
 	!endif
+	!ifdef - SHUFFLE_ELEMENTS_ON_DUNGEONS
+		Items.EarthElement;		DungeonMajor;	Prize
+		Items.FireElement;		DungeonMajor;	Prize
+		Items.WaterElement;		DungeonMajor;	Prize
+		Items.WindElement;		DungeonMajor;	Prize
+	!endif
+	!ifdef - SHUFFLE_ELEMENTS_ON_REGIONS
+		Items.EarthElement;		DungeonMajor;	PrizeOutside
+		Items.FireElement;		DungeonMajor;	PrizeOutside
+		Items.WaterElement;		DungeonMajor;	PrizeOutside
+		Items.WindElement;		DungeonMajor;	PrizeOutside
+	!endif
+	!ifdef - SHUFFLE_ELEMENTS_ON
+		Items.EarthElement;		Major;
+		Items.FireElement;		Major;
+		Items.WaterElement;		Major;
+		Items.WindElement;		Major;
+	!endif
+!endif
 !ifndef - START_GRIP_RING
 	Items.GripRing;	Major;
 !else
@@ -6925,19 +6962,19 @@ Inaccessible;    Helper;; Items.Untyped.0xFF:0xFF  # ask for 255 of them for goo
 	!define - DHCCHEST - Inaccessible
 !endif
 # Dungeon Item Shuffle Rules
-!define - DWS_OUTSIDE - 	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - COF_OUTSIDE - 	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - FOW_OUTSIDE - 	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - POW_OUTSIDE -	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - DHC_OUTSIDE -	:DHCSmallOutside	:DHCBigOutside	:DHCMapOutside	:DHCCompassOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - RC_OUTSIDE -	:RCSmallOutside														:SmallOutside	:BigOutside	:MapOutside	:CompassOutside
-!define - DWS_INSIDE - `DWS_OUTSIDE`	:DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:Small	:Big	:Map	:Compass
-!define - COF_INSIDE - `COF_OUTSIDE`	:CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:Small	:Big	:Map	:Compass	:CoF
-!define - FOW_INSIDE - `FOW_OUTSIDE`	:FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:Small	:Big	:Map	:Compass
-!define - TOD_INSIDE - 				:ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:Small	:Big	:Map	:Compass
-!define - POW_INSIDE - `POW_OUTSIDE`	:PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:Small	:Big	:Map	:Compass
-!define - DHC_INSIDE - `DHC_OUTSIDE`	:DHCSmall	:DHCBig	:DHCMap	:DHCCompass	:Small	:Big	:Map	:Compass
-!define - RC_INSIDE - `RC_OUTSIDE`		:RCSmall									:Small	:Big	:Map	:Compass
+!define - DWS_OUTSIDE - 	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside	:DWSPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - COF_OUTSIDE - 	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoFPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - FOW_OUTSIDE - 	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside	:FoWPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - POW_OUTSIDE -	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside	:PoWPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - DHC_OUTSIDE -	:DHCSmallOutside	:DHCBigOutside	:DHCMapOutside	:DHCCompassOutside	:DHCPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - RC_OUTSIDE -	:RCSmallOutside															:RCPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+!define - DWS_INSIDE - `DWS_OUTSIDE`	:DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize	:Small	:Big	:Map	:Compass	:Prize
+!define - COF_INSIDE - `COF_OUTSIDE`	:CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:Small	:Big	:Map	:Compass	:Prize	:CoF
+!define - FOW_INSIDE - `FOW_OUTSIDE`	:FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize	:Small	:Big	:Map	:Compass	:Prize
+!define - TOD_INSIDE - 				:ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize	:Small	:Big	:Map	:Compass	:Prize
+!define - POW_INSIDE - `POW_OUTSIDE`	:PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize	:Small	:Big	:Map	:Compass	:Prize
+!define - DHC_INSIDE - `DHC_OUTSIDE`	:DHCSmall	:DHCBig	:DHCMap	:DHCCompass	:DHCPrize	:Small	:Big	:Map	:Compass	:Prize
+!define - RC_INSIDE - `RC_OUTSIDE`		:RCSmall								:RCPrize	:Small	:Big	:Map	:Compass	:Prize
 !ifndef - NO_RED_FUSIONS
 	!define - POW_F_OUTSIDE - 
 !else
@@ -7011,36 +7048,36 @@ Inaccessible;    Helper;; Items.Untyped.0xFF:0xFF  # ask for 255 of them for goo
 	!define - DHC_INSIDE_COM - `DHC_INSIDE`
 !endif
 !ifdef - UNREQSUR
-	!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside
-	!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoF	
-	!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside
-	!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass
-	!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside
-	!define - RC_PRIZE - 	:RCSmall									:RCSmallOutside
+	!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside	:DWSPrizeOutside
+	!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoFPrizeOutside	:CoF
+	!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside	:FoWPrizeOutside
+	!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize
+	!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside	:PoWPrizeOutside
+	!define - RC_PRIZE - 	:RCSmall							:RCPrize	:RCSmallOutside															:RCPrizeOutside
 !else
 	!ifdef - BARRENSUR
-		!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside
-		!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoF	
-		!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside
-		!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass
-		!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside
-		!define - RC_PRIZE - 	:RCSmall 								:RCSmallOutside
+		!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize	:DWSSmallOutside	:DWSBigOutside	:DWSMapOutside	:DWSCompassOutside	:DWSPrizeOutside
+		!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoFPrizeOutside	:CoF
+		!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside	:FoWPrizeOutside
+		!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize
+		!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside	:PoWPrizeOutside
+		!define - RC_PRIZE - 	:RCSmall 							:RCPrize	:RCSmallOutside															:RCPrizeOutside
 	!else
 		!ifdef - UNREQ
-			!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass
-			!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoF
-			!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass
-			!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass
-			!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass
-			!define - RC_PRIZE - 	:RCSmall
+			!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize
+			!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:CoF
+			!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize
+			!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize
+			!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize
+			!define - RC_PRIZE - 	:RCSmall							:RCPrize
 		!else
 			!ifdef - BARREN
-				!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass
-				!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoF
-				!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass
-				!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass
-				!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass
-				!define - RC_PRIZE - 	:RCSmall
+				!define - DWS_PRIZE - :DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize
+				!define - COF_PRIZE - :CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:CoF
+				!define - FOW_PRIZE - :FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize
+				!define - TOD_PRIZE - :ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize
+				!define - POW_PRIZE - :PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize
+				!define - RC_PRIZE - 	:RCSmall							:RCPrize
 			!else
 				!define - DWS_PRIZE - `DWS_INSIDE`
 				!define - COF_PRIZE - `COF_INSIDE`

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -22,9 +22,9 @@
 #   DungeonEntrance - Used to specify that this location represents a dungeon entrance. Only items of type DungeonEntrance can be placed here. If there are any unfilled locations after placing all DungeonEntrance items, randomization will fail.
 #   DungeonConstraint - Used by dummy items to manipulate where other items can get placed in dungeons, only items of type DungeonConstraint can be placed here. If there are any unfilled locations after placing all DungeonConstraint items, randomization will fail.
 #   OverworldConstraint - Used by dummy items to manipulate where other items can get placed in the overworld, only items of type OverworldConstraint can be placed here. If there are any unfilled locations after placing all OverworldConstraint items, randomization will fail.
-#   DungeonPrize - Used to specify that a location can have an item with type DungeonPrize placed on it, if any locations are left after placing prizes, they will get added to the Dungeon pool.
+#   DungeonPrize - Used to specify that a location can have an item with type DungeonPrize assigned to it (and placed there if the placement rule is not overridden using !prizeplacement), if any locations are left after placing prizes, they will get added to the Dungeon pool.
 #   Major - Used to specify that only items of type Major can be placed here. Any locations that aren't filled after placing all Major items will be added to the Any pool.
-#   Dungeon - Used to specify that any item with type DungeonMajor can be placed here. Any locations that aren't filled after placing all DungeonMajor items will be added to the Any pool.
+#   Dungeon - Used to specify that any item with type DungeonMajor or DungeonMinor can be placed here. Any locations that aren't filled after placing all DungeonMajor and DungeonMinor items will be added to the Any pool.
 #   Any - Used to specify that any item with type DungeonMajor, DungeonMinor, Major, Minor, or Filler can be placed here.
 #   Minor - Used to specify that only items of type Minor can be placed here. Any locations that aren't filled after placing all Minor items will be filled with Filler items.
 #   Inaccessible - No items are randomized to this location, and it is ignored by logic.
@@ -34,7 +34,7 @@
 #   DungeonEntrance - Used to specify that this item can only be placed on locations of type DungeonEntrance. If there are any items left in this group after all DungeonEntrance locations are filled then randomization will fail.
 #   DungeonConstraint - Used to specify that this item can only be placed on locations of type DungeonConstraint. If there are any items left in this group after all DungeonConstraint locations are filled then randomization will fail.
 #   OverworldConstraint - Used to specify that this item can only be placed on locations of type OverworldConstraint. If there are any items left in this group after all OverworldConstraint locations are filled then randomization will fail.
-#   DungeonPrize - Used to specify that this item can only be placed on locations of type DungeonPrize. If there are any items left in this group after all DungeonPrize locations are filled then randomization will fail.
+#   DungeonPrize - Used to specify that this item can only be placed on locations of type DungeonPrize, or connected locations determined through !prizeplacement. If there are any items left in this group after all DungeonPrize locations are filled then randomization will fail.
 #   DungeonMajor - Used to specify that this item can only be placed on locations of type Dungeon. If there are any items left in this group after all DungeonPrize locations are filled then randomization will fail.
 #   DungeonMinor - Used to specify that this item can only be placed after Dungeon Majors, and can only be placed on locations of type Dungeon. If there are any items left in this group after all DungeonPrize locations are filled then randomization will fail.
 #   Major - Used to specify that this item can only be placed on locations of type Major, Dungeon, and then Any in that order.
@@ -42,7 +42,7 @@
 #   Filler - Used to specify that this item should be used to fill any unfilled locations after all other items are placed. Items with the Filler type will be randomly chosen for each location left when randomization ends, and items can be chosen multiple times. Increase the number of a specific item in the Filler pool to increase the odds of that item being used.
 #
 # Items are built up in two different ways:
-#   In the item pool, they are - Items.(type).[subtype]:[amount]; (item pool type); [dungeon_id]
+#   In the item pool, they are - Items.(type).[subtype]:[amount]; (item pool type); [dungeon id]
 #    On unshuffled locations, they are - Items.(type).[subtype]
 #
 # A location is built up as (name):[dungeon id 1]:[dungeon id 2]:...:[dungeon id N]; (location type); (address); [logic]; [item] (Only applies to Unshuffled locations)
@@ -79,6 +79,8 @@
 # !replaceincrement - (item) - (amount) - (to replace) : replaces the first (amount) occurrences of any items in (to replace) with (item), the subtype of (item) increases by 1 every time it replaces something.
 # !addition - (define name) - (values)                 : adds all , seperated number values in (values) together and sets (define name) to that value.
 # !settype - (item) - (location type)                  : set all occurrences of (item) to be of type (location type).
+# !import - (function name)                            : tells the shuffler to perform certain logical checks before placing an item, the allowed values for (function name) are defined in LogicImport.cs.
+# !prizeplacement - (location name) - [dungeon id]     : when a DungeonPrize item gets assigned to the DungeonPrize location with the given (location name), instead of placing the item there, the item will get placed later within the given [dungeon id] (or anywhere if no [dungeon id] is given).
 #
 # = Location Logic =
 # all logic symbols other than , are to be put in ()
@@ -89,7 +91,7 @@
 # (| (item), ~(item)~)      : an OR, "(|Items.x, Items.y)" will need either x or y.
 # (& (item), ~(item)~)      : an AND, "(&Items.x, Items.y)" will need both x and y.
 # (+(value), ~(itemvalue)~) : a count, "(+50, Items.x:2, Items.y)" x is worth 2, y is worth 1, this needs enough x's and y's to reach the value 50.
-#~(item)                    : a NOT item, prevents the item chosen from being placed at this location, can only be used for item locations and not helpers.eg: (| Items.a , (&Items.b, ~Items.c)) 
+# ~(item)                   : a NOT item, prevents the item chosen from being placed at this location, can only be used for item locations and not helpers.eg: (| Items.a , (&Items.b, ~Items.c)) 
 
 #Settings options displayed in the rando UI
 

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -101,6 +101,7 @@
 !dropdown - Main Settings - Setting - Dungeon Settings - BIG_KEYS_SETTING - Big Keys - Big Keys - BIG_KEYS_STANDARD - Removed (Keasy) - BIG_KEASY - 'Removed': Big keys are removed, All locked Boss doors are open from the start. - Vanilla - BIG_KEYS_VANILLA - 'Vanilla': Big keys are in the same places they appear in the vanilla game. - Own Dungeon - BIG_KEYS_STANDARD - 'Own Dungeon': Big keys are randomized to locations in the dungeon they are used in. - Own Region - BIG_KEYS_REGION - 'Own Region': Big keys are randomized inside and in the vicinity of their own dungeon. - Any Dungeon - BIG_KEYS_DUNGEON - 'Any Dungeon': Big keys are randomized inside all dungeons. - Any Region - BIG_KEYS_REGDUN - 'Any Region': Big keys are randomized inside and in the vicinity of all dungeons. - Anywhere (Keysanity) - BIG_KEYSANITY  - 'Anywhere': Big keys are randomized to any location in the world, expect to return to dungeons multiple times.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
 !dropdown - Main Settings - Setting - Dungeon Settings - SHUFFLE_ELEMENTS - Shuffle Elements - Shuffle Elements - SHUFFLE_ELEMENTS_OFF - Vanilla - SHUFFLE_ELEMENTS_VANILLA - 'Vanilla': The Elements are found in their vanilla locations. Will shuffle dungeon rewards if all 4 elements are required to complete the seed but the vanilla location is not accessible. - Dungeon Rewards - SHUFFLE_ELEMENTS_OFF - 'Dungeon Rewards': Elements are shuffled among the 6 Dungeon Rewards. - Own Dungeon - SHUFFLE_ELEMENTS_DUNGEON - 'Own Dungeon': Elements are shuffled among the 6 Dungeons that have a Reward at the end, but are then placed in a random location within that Dungeon. - Own Region - SHUFFLE_ELEMENTS_REGION - 'Own Region': Elements are shuffled among the 6 Dungeons that have a Reward at the end, but are then placed in a random location inside or in the vicinity of that Dungeon. - Any Dungeon - SHUFFLE_ELEMENTS_ON_DUNGEONS - 'Any Dungeon': Elements are freely shuffled across all locations in all 7 Dungeons. The Element icons on the map are removed. - Any Region - SHUFFLE_ELEMENTS_ON_REGIONS - 'Any Region': Elements are freely shuffled inside and in the vicinity of all 7 Dungeons. The Element icons on the map are removed. - Anywhere - SHUFFLE_ELEMENTS_ON - 'Anywhere': Elements are shuffled anywhere in the world. The Element icons on the map are removed.\n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.\nDHC Region: 'Castle Gardens (Not Moat)', If Pedestal Items is enabled: 'Sanctuary Pedestal'.
 !dropdown - Main Settings - Setting - Dungeon Settings - DUNGEON - NonElement Dungeons - NonElement Dungeons, This setting is disabled when 'Shuffle Elements' is set to 'Any Dungeon', 'Any Region' or 'Anywhere' or when 'Dungeons Required' is set to '5' or '6'. - NONE - Standard - NONE - 'Standard': NonElement Dungeons have no special rules. - Unrequired - UNREQ - 'Unrequired': NonElement Dungeons do not have items required to beat the game. - Barren - BARREN - 'Barren': NonElement Dungeons only contain junk items. - Regions Unrequired - UNREQSUR - 'Regions Unrequired': NonElement Dungeons and their Regions do not contain items needed to beat the game. - Regions Barren - BARRENSUR - 'Regions Barren': NonElement Dungeons and their Regions only contain junk items. \n\nDWS Region: 'Minish Village', 'Belari's House', 'Chest near Belari', 'Minish Cave near Belari'.\nCoF Region: 'Melari's Mines', 'Melari's Mines Outside Path', 'Pre Melari Block Puzzle Chest'.\nFOW Region: 'Wind Ruins'.\nTOD Region: 'Nothing'.\nRC Region: 'Graveyard (Not Dampe)'.\nPOW Region: If Red Fusions are Removed: 'Wind Tribe', Otherwise: 'Upper Wind Tribe'.
+!flag - Main Settings - Setting - Dungeon Settings - DHC_BARREN - DHC is Barren - If enabled will completely fill the interior of Dark Hyrule Castle with junk aside from dungeon items that have to be placed in there because of the dungeon item settings.\n\nFor technical reasons, dungeon items that are allowed to be placed outside of DHC (and its region) will always be placed outside DHC. Also, setting dungeon items to 'Own Region' will make the corresponding DHC items behave like in 'Own Dungeon'.
 
 !dropdown - Main Settings - Setting - Requirements - DHC_SETTING - Dark Hyrule Castle Opens - Dark Hyrule Castle is the last dungeon in the game, it has the final boss Vaati. - OPENDHC - Never Open - NODHC - 'Never Open': A barrier is placed at the front of the dungeon, The game ends when you visit the sanctuary after completing all the requirements. - After Requirements - NORMALDHC - 'After Requirements': A barrier is placed at the front of the dungeon, This barrier is removed when you visit the sanctuary after completing ALL the requirements. The game ends when you defeat Vaati. - Always Open - OPENDHC - 'Always Open': There is no barrier at the front of the dungeon, the game ends when you defeat Vaati.
 !dropdown - Main Settings - Setting - Requirements - REQUIREMENT_ITEM - Requirement Reward - An item that the player receives once they meet the selected requirements. - REQUIREMENT_ITEM_DHC_BK - Disabled - REQUIREMENT_ITEM_NONE - 'Disabled': No extra item is awarded for requirement completion. - DHC Big Key - REQUIREMENT_ITEM_DHC_BK - 'DHC Big Key': The DHC Big Key is instantly awarded to the player once they meet the selected requirements. Overrides whatever the general Big Key setting is. - Random Item - REQUIREMENT_ITEM_RANDOM - 'Random Item': An item from the random item pool is instantly awarded to the player once they meet the selected requirements.
@@ -6966,15 +6967,22 @@ Inaccessible;    Helper;; Items.Untyped.0xFF:0xFF  # ask for 255 of them for goo
 !define - COF_OUTSIDE - 	:CoFSmallOutside	:CoFBigOutside	:CoFMapOutside	:CoFCompassOutside	:CoFPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
 !define - FOW_OUTSIDE - 	:FoWSmallOutside	:FoWBigOutside	:FoWMapOutside	:FoWCompassOutside	:FoWPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
 !define - POW_OUTSIDE -	:PoWSmallOutside	:PoWBigOutside	:PoWMapOutside	:PoWCompassOutside	:PoWPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
-!define - DHC_OUTSIDE -	:DHCSmallOutside	:DHCBigOutside	:DHCMapOutside	:DHCCompassOutside	:DHCPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
 !define - RC_OUTSIDE -	:RCSmallOutside															:RCPrizeOutside	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
 !define - DWS_INSIDE - `DWS_OUTSIDE`	:DWSSmall	:DWSBig	:DWSMap	:DWSCompass	:DWSPrize	:Small	:Big	:Map	:Compass	:Prize
 !define - COF_INSIDE - `COF_OUTSIDE`	:CoFSmall	:CoFBig	:CoFMap	:CoFCompass	:CoFPrize	:Small	:Big	:Map	:Compass	:Prize	:CoF
 !define - FOW_INSIDE - `FOW_OUTSIDE`	:FoWSmall	:FoWBig	:FoWMap	:FoWCompass	:FoWPrize	:Small	:Big	:Map	:Compass	:Prize
 !define - TOD_INSIDE - 				:ToDSmall	:ToDBig	:ToDMap	:ToDCompass	:ToDPrize	:Small	:Big	:Map	:Compass	:Prize
 !define - POW_INSIDE - `POW_OUTSIDE`	:PoWSmall	:PoWBig	:PoWMap	:PoWCompass	:PoWPrize	:Small	:Big	:Map	:Compass	:Prize
-!define - DHC_INSIDE - `DHC_OUTSIDE`	:DHCSmall	:DHCBig	:DHCMap	:DHCCompass	:DHCPrize	:Small	:Big	:Map	:Compass	:Prize
 !define - RC_INSIDE - `RC_OUTSIDE`		:RCSmall								:RCPrize	:Small	:Big	:Map	:Compass	:Prize
+!ifndef - DHC_BARREN
+	!define - DHC_OUTSIDE -	:DHCSmallOutside	:DHCBigOutside	:DHCMapOutside	:DHCCompassOutside						:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+	!define - DHC_INSIDE - `DHC_OUTSIDE`	:DHCSmall	:DHCBig	:DHCMap	:DHCCompass				:Small	:Big	:Map	:Compass	:Prize
+!else
+	# Dungeon items for other dungeons can be placed outside DHC, but not inside
+	!define - DHC_OUTSIDE -	:SmallOutside	:BigOutside	:MapOutside	:CompassOutside	:PrizeOutside
+	# Because we need to know the amount of needed junk items in advance, regional DHC dungeon items will always be placed inside DHC, and in other settings that allow placement outside of DHC they will always be placed outside of DHC
+	!define - DHC_INSIDE - 	:DHCSmallOutside	:DHCBigOutside	:DHCMapOutside	:DHCCompassOutside	:DHCSmall	:DHCBig	:DHCMap	:DHCCompass
+!endif
 !ifndef - NO_RED_FUSIONS
 	!define - POW_F_OUTSIDE - 
 !else
@@ -7085,6 +7093,64 @@ Inaccessible;    Helper;; Items.Untyped.0xFF:0xFF  # ask for 255 of them for goo
 				!define - TOD_PRIZE - `TOD_INSIDE`
 				!define - POW_PRIZE - `POW_INSIDE`
 				!define - RC_PRIZE - 	`RC_INSIDE`
+			!endif
+		!endif
+	!endif
+!endif
+
+# Junk fill for Barren DHC
+!ifndef - NODHC
+	!ifdef - DHC_BARREN
+		Items.Rupee5;		DungeonMinor;	DHCSmall
+		!ifndef - MAP_VANILLA
+			!ifndef - MAP_STANDARD
+				!ifndef - MAP_REGION
+					Items.Rupee5;		DungeonMinor;	DHCMap
+				!endif
+			!endif
+		!endif
+		!ifndef - COMPASS_VANILLA
+			!ifndef - COMPASS_STANDARD
+				!ifndef - COMPASS_REGION
+					Items.Rupee5;		DungeonMinor;	DHCCompass
+				!endif
+			!endif
+		!endif
+		!ifndef - SMALL_KEYS_VANILLA
+			!ifndef - SMALL_KEYS_STANDARD
+				!ifndef - SMALL_KEYS_REGION
+					!define - DHC_JUNK_NO_SMALL_KEYS
+					Items.Rupee5:5;		DungeonMinor;	DHCSmall
+				!endif
+			!endif
+		!endif
+		!ifndef - DHC_JUNK_NO_SMALL_KEYS
+			!ifndef - DHC1KEY
+				!ifndef - SMALL_KEYS_VANILLA
+					!define - DHC_JUNK_SMALL - DHCSmall
+				!else
+					!define - DHC_JUNK_SMALL - DHCSmallV
+				!endif
+				!ifdef - DHC2KEY
+					Items.Rupee5:2;		DungeonMinor;	`DHC_JUNK_SMALL`
+				!else
+					!ifndef - DHC5KEY
+						Items.Rupee5:3;		DungeonMinor;	`DHC_JUNK_SMALL`
+					!else
+						Items.Rupee5:4;		DungeonMinor;	`DHC_JUNK_SMALL`
+					!endif
+				!endif
+			!endif
+		!endif
+		!ifdef - REQUIREMENT_ITEM_DHC_BK
+			Items.Rupee5;		DungeonMinor;	DHCBig
+		!else
+			!ifndef - BIG_KEYS_VANILLA
+				!ifndef - BIG_KEYS_STANDARD
+					!ifndef - BIG_KEYS_REGION
+						Items.Rupee5;		DungeonMinor;	DHCBig
+					!endif
+				!endif
 			!endif
 		!endif
 	!endif


### PR DESCRIPTION
This adds the ability to shuffle dungeon prizes in 2 stages: First assign the DungeonPrize items to DungeonPrize locations, and then place each item in a region tied to the location it got assigned to. Whenever such a region is not specified, the normal behavior of placing the item at the location is used.
The logic file makes use of this by offering new options where the 4 elements are all assigned to 4 dungeons like usual (which can be spotted on the overworld map), but then randomly placed within the dungeon (or its surrounding area).
There is also a new option to fill DHC with junk, meant to be similar to the option for barren non-element dungeons.
Barren or Unrequired Cave of Flames now also affects locations form fusions that are locked behind completion of CoF, like was already the case with the Melari location. This change does not affect Open Fusions settings.