### PR TITLE
Accurate Kinstone Pack item pool

### DIFF
--- a/RandomizerCore/Randomizer/Parser/Parser.cs
+++ b/RandomizerCore/Randomizer/Parser/Parser.cs
@@ -219,7 +219,14 @@ public class Parser
                 if (Enum.TryParse(subParts[2], out KinstoneType subKinstoneType))
                     subType = (byte)subKinstoneType;
 
-        var amount = itemParts.Length > 1 ? int.Parse(itemParts[1]) : 1;
+        var amount = 1;
+        if (itemParts.Length > 1)
+        {
+            var amountSubParts = itemParts[1].Split('.');
+            amount = int.Parse(amountSubParts[0]);
+            if (amountSubParts.Length > 1)
+                amount = (int)Math.Ceiling((double)amount / int.Parse(amountSubParts[1]));
+        }
 
         if (!Enum.TryParse(allItemParts[1], out ItemPool itemShufflePool))
             throw new ParserException("Item has invalid shuffle pool!");
@@ -443,8 +450,8 @@ public class Parser
                         if (trimmedLine.Split('.')[0] == "Items")
                         {
                             //It is an item, parse it as one
-                            var newItem = GetItems(trimmedLine);
-                            items.AddRange(newItem);
+                            var newItems = GetItems(trimmedLine);
+                            items.AddRange(newItems);
                         }
                         else
                         {

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -4680,21 +4680,17 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 			!endif
 			Items.Kinstone.GoldenFalls;			Major;
 			!ifdef - GOLD1MAX
-				Items.Kinstone.GoldenCloudTops;		Major;
 				!undefine - GOLD1MULTIPLIER
 				!define - GOLD1MULTIPLIER - 5
 				!eventdefine - kinstoneMultiplierGoldCloud - 5
-			!else
-				Items.Kinstone.GoldenCloudTops:5;	Major;
 			!endif
 			!ifdef - GOLD2MAX
-				Items.Kinstone.GoldenSwamp;		Major;
 				!undefine - GOLD2MULTIPLIER
 				!define - GOLD2MULTIPLIER - 3
 				!eventdefine - kinstoneMultiplierGoldSwamp - 3
-			!else
-				Items.Kinstone.GoldenSwamp:3;		Major;
 			!endif
+			Items.Kinstone.GoldenCloudTops:5.`GOLD1MULTIPLIER`;	Major;
+			Items.Kinstone.GoldenSwamp:3.`GOLD2MULTIPLIER`;		Major;
 			CanFuseGoldTornado;  Helper;; (+5, Items.Kinstone.GoldenCloudTops:`GOLD1MULTIPLIER`)
 			CanFuseGoldTotem;    Helper;; (+3, Items.Kinstone.GoldenSwamp:`GOLD2MULTIPLIER`)
 			CanFuseGoldCrown;    Helper;; Items.Kinstone.GoldenFalls
@@ -4706,15 +4702,13 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 					Items.Kinstone.GoldenCloudTops:5;	Minor;
 				!endif
 			!endif
-			!eventdefine - combineKinstonesGold
 			!ifdef - GOLD1MAX
-				Items.Kinstone.GoldenCloudTops;			Major;
 				!undefine - GOLD1MULTIPLIER
-				!define - GOLD1MULTIPLIER - 10
+				!define - GOLD1MULTIPLIER - 9
 				!eventdefine - kinstoneMultiplierGoldCloud - 9
-			!else
-				Items.Kinstone.GoldenCloudTops:9;		Major;
 			!endif
+			!eventdefine - combineKinstonesGold
+			Items.Kinstone.GoldenCloudTops:9.`GOLD1MULTIPLIER`;	Major;
 			CanFuseGoldTornado;  Helper;; (+9, Items.Kinstone.GoldenCloudTops:`GOLD1MULTIPLIER`)
 			CanFuseGoldTotem;    Helper;; (+9, Items.Kinstone.GoldenCloudTops:`GOLD1MULTIPLIER`)
 			# The Veil Falls Gold Fusion only requires 4 Golden Kinstones if Cloud Tops is locked behind it, as then you could not waste Gold Kinstones there
@@ -4828,27 +4822,21 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 			!ifdef - REDWMAX
 				!eventdefine - kinstoneMultiplierRedW - `REDWTOTAL`
 				!undefine - REDWMULTIPLIER
-				!undefine - REDWTOTAL
-				!define - REDWMULTIPLIER - 10
-				!define - REDWTOTAL - 1
+				!define - REDWMULTIPLIER - `REDWTOTAL`
 			!endif
 			!ifdef - REDVMAX
 				!eventdefine - kinstoneMultiplierRedV - `REDVTOTAL`
 				!undefine - REDVMULTIPLIER
-				!undefine - REDVTOTAL
-				!define - REDVMULTIPLIER - 10
-				!define - REDVTOTAL - 1
+				!define - REDVMULTIPLIER - `REDVTOTAL`
 			!endif
 			!ifdef - REDEMAX
 				!eventdefine - kinstoneMultiplierRedE - `REDETOTAL`
 				!undefine - REDEMULTIPLIER
-				!undefine - REDETOTAL
-				!define - REDEMULTIPLIER - 10
-				!define - REDETOTAL - 1
+				!define - REDEMULTIPLIER - `REDETOTAL`
 			!endif
-			Items.Kinstone.RedW:`REDWTOTAL`;	Major;
-			Items.Kinstone.RedV:`REDVTOTAL`;	Major;
-			Items.Kinstone.RedE:`REDETOTAL`;	Major;
+			Items.Kinstone.RedW:`REDWTOTAL`.`REDWMULTIPLIER`;	Major;
+			Items.Kinstone.RedV:`REDVTOTAL`.`REDVMULTIPLIER`;	Major;
+			Items.Kinstone.RedE:`REDETOTAL`.`REDEMULTIPLIER`;	Major;
 			CanFuseRedW;			Helper;;	(+`REDWTOTAL`, Items.Kinstone.RedW:`REDWMULTIPLIER`)
 			CanFuseRedV;			Helper;;	(+`REDVTOTAL`, Items.Kinstone.RedV:`REDVMULTIPLIER`)
 			CanFuseRedMinish0;	Helper;;	(+`REDVTOTAL`, Items.Kinstone.RedV:`REDVMULTIPLIER`)
@@ -4919,12 +4907,10 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 			!ifdef - REDWMAX
 				!eventdefine - kinstoneMultiplierRedW - `REDWTOTAL`
 				!undefine - REDWMULTIPLIER
-				!undefine - REDWTOTAL
-				!define - REDWMULTIPLIER - 30
-				!define - REDWTOTAL - 1
+				!define - REDWMULTIPLIER - `REDWTOTAL`
 			!endif
 			!eventdefine - combineKinstonesRed
-			Items.Kinstone.RedW:`REDWTOTAL`;	Major;
+			Items.Kinstone.RedW:`REDWTOTAL`.`REDWMULTIPLIER`;	Major;
 			CanFuseRedW;			Helper;;	(+`REDWTOTAL`, Items.Kinstone.RedW:`REDWMULTIPLIER`)
 			CanFuseRedV;			Helper;;	(+`REDWTOTAL`, Items.Kinstone.RedW:`REDWMULTIPLIER`)
 			CanFuseRedMinish0;	Helper;;	(+`REDWTOTAL2`, Items.Kinstone.RedW:`REDWMULTIPLIER`)
@@ -5009,50 +4995,48 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 		GoronLeftFusion;		Helper;;																																	#GoronMerchant			33
 	!else
 		!ifndef - COMBINED_BLUE_FUSIONS
-			!ifdef - BLUELMAX
-				!undefine - BLUELMULTIPLIER
-				!define - BLUELMULTIPLIER - 10
-				!define - BLUELTOTAL - 1
-				!eventdefine - kinstoneMultiplierBlueL - 9
-			!else
-				!define - BLUELTOTAL - 9
-			!endif
-			!ifdef - BLUESMAX
-				!undefine - BLUESMULTIPLIER
-				!define - BLUESMULTIPLIER - 10
-				!define - BLUESTOTAL - 1
-				!eventdefine - kinstoneMultiplierBlueS - 9
-			!else
-				!define - BLUESTOTAL - 9
-			!endif
-			Items.Kinstone.BlueL:`BLUELTOTAL`;	Major;
-			Items.Kinstone.BlueS:`BLUESTOTAL`;	Major;
-			CanFuseBlueL;    		Helper;; (+9, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
-			CanFuseBlueS;    		Helper;; (+9, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
-			CanFuseBlue4Wall;		Helper;; (+8, Items.Kinstone.BlueL:`BLUELMULTIPLIER`), (+8, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
-			CanFuseBlueGhost;		Helper;; (+9, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
+			!define - BLUELTOTAL - 9
+			!define - BLUESTOTAL - 9
 			!ifdef - ITEM_POOL_PLENTIFUL
 				Items.Kinstone.BlueL:2;	Minor;
 				Items.Kinstone.BlueS:2;	Minor;
 			!endif
-		!else
 			!ifdef - BLUELMAX
 				!undefine - BLUELMULTIPLIER
-				!define - BLUELMULTIPLIER - 20
-				!define - BLUELTOTAL - 1
-				!eventdefine - kinstoneMultiplierBlueL - 18
-			!else
-				!define - BLUELTOTAL - 18
+				!define - BLUELMULTIPLIER - `BLUELTOTAL`
+				!eventdefine - kinstoneMultiplierBlueL - `BLUELTOTAL`
+			!endif
+			!ifdef - BLUESMAX
+				!undefine - BLUESMULTIPLIER
+				!define - BLUESMULTIPLIER - `BLUESTOTAL`
+				!eventdefine - kinstoneMultiplierBlueS - `BLUESTOTAL`
+			!endif
+			Items.Kinstone.BlueL:`BLUELTOTAL`.`BLUELMULTIPLIER`;	Major;
+			Items.Kinstone.BlueS:`BLUESTOTAL`.`BLUESMULTIPLIER`;	Major;
+			CanFuseBlueL;    		Helper;; (+9, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
+			CanFuseBlueS;    		Helper;; (+9, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
+			CanFuseBlue4Wall;		Helper;; (+8, Items.Kinstone.BlueL:`BLUELMULTIPLIER`), (+8, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
+			CanFuseBlueGhost;		Helper;; (+9, Items.Kinstone.BlueS:`BLUESMULTIPLIER`)
+		!else
+			!define - BLUELTOTAL - 18
+			!ifdef - ITEM_POOL_PLENTIFUL
+				!ifdef - BLUELMAX
+					Items.Kinstone.BlueL:2;	Minor;
+				!else
+					Items.Kinstone.BlueL:4;	Minor;
+				!endif
+			!endif
+			!ifdef - BLUELMAX
+				!undefine - BLUELMULTIPLIER
+				!define - BLUELMULTIPLIER - `BLUELTOTAL`
+				!eventdefine - kinstoneMultiplierBlueL - `BLUELTOTAL`
 			!endif
 			!eventdefine - combineKinstonesBlue
-			Items.Kinstone.BlueL:`BLUELTOTAL`;	Major;
+			Items.Kinstone.BlueL:`BLUELTOTAL`.`BLUELMULTIPLIER`;	Major;
 			CanFuseBlueL;			Helper;; (+18, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
 			CanFuseBlueS;			Helper;; (+18, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
 			CanFuseBlue4Wall;		Helper;; (+16, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
 			CanFuseBlueGhost;		Helper;; (+17, Items.Kinstone.BlueL:`BLUELMULTIPLIER`)
-			!ifdef - ITEM_POOL_PLENTIFUL
-				Items.Kinstone.BlueL:4;	Minor;
-			!endif
 		!endif
 		CandyFusion;			Helper;;	Helpers.CanFuseBlueL, Helpers.Library																								#TrilbyPlatform			22
 		LakeEastMinishFusion;	Helper;;	Helpers.CanFuseBlueL, Locations.Hylia_NorthMinishHole_Chest																			#LakeBeanstalk			23
@@ -5388,27 +5372,21 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 			!ifdef - GREENCMAX
 				!eventdefine - kinstoneMultiplierGreenC - `GREENCTOTAL`
 				!undefine - GREENCMULTIPLIER
-				!undefine - GREENCTOTAL
-				!define - GREENCMULTIPLIER - 20
-				!define - GREENCTOTAL - 1
+				!define - GREENCMULTIPLIER - `GREENCTOTAL`
 			!endif
 			!ifdef - GREENPMAX
 				!eventdefine - kinstoneMultiplierGreenP - `GREENPTOTAL`
 				!undefine - GREENPMULTIPLIER
-				!undefine - GREENPTOTAL
-				!define - GREENPMULTIPLIER - 20
-				!define - GREENPTOTAL - 1
+				!define - GREENPMULTIPLIER - `GREENPTOTAL`
 			!endif
 			!ifdef - GREENGMAX
 				!eventdefine - kinstoneMultiplierGreenG - `GREENGTOTAL`
 				!undefine - GREENGMULTIPLIER
-				!undefine - GREENGTOTAL
-				!define - GREENGMULTIPLIER - 20
-				!define - GREENGTOTAL - 1
-			!endif		
-			Items.Kinstone.GreenC:`GREENCTOTAL`;	Major;
-			Items.Kinstone.GreenP:`GREENPTOTAL`;	Major;
-			Items.Kinstone.GreenG:`GREENGTOTAL`;	Major;
+				!define - GREENGMULTIPLIER - `GREENGTOTAL`
+			!endif
+			Items.Kinstone.GreenC:`GREENCTOTAL`.`GREENCMULTIPLIER`;	Major;
+			Items.Kinstone.GreenP:`GREENPTOTAL`.`GREENPMULTIPLIER`;	Major;
+			Items.Kinstone.GreenG:`GREENGTOTAL`.`GREENGMULTIPLIER`;	Major;
 			CanFuseGreenC;   		Helper;; (+`GREENCTOTAL`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)
 			CanFuseGreenCShared1;	Helper;; (+`GREENCTOTAL5`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)
 			CanFuseGreenCShared2;	Helper;; (+`GREENCTOTAL4`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)
@@ -5836,12 +5814,10 @@ ShopScrubCrenel;		Helper;;	(|(+210, Items.Rupee1, Items.Rupee5:5, Items.Rupee20:
 			!ifdef - GREENCMAX
 				!eventdefine - kinstoneMultiplierGreenC - `GREENCTOTAL`
 				!undefine - GREENCMULTIPLIER
-				!undefine - GREENCTOTAL
-				!define - GREENCMULTIPLIER - 50
-				!define - GREENCTOTAL - 1
+				!define - GREENCMULTIPLIER - `GREENCTOTAL`
 			!endif
 			!eventdefine - combineKinstonesGreen
-			Items.Kinstone.GreenC:`GREENCTOTAL`;	Major;
+			Items.Kinstone.GreenC:`GREENCTOTAL`.`GREENCMULTIPLIER`;	Major;
 			CanFuseGreenC;   		Helper;; (+`GREENCTOTAL`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)
 			CanFuseGreenG;   		Helper;; (+`GREENCTOTAL`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)
 			CanFuseGreenTFZ1;		Helper;; (+`GREENCTOTAL2`, Items.Kinstone.GreenC:`GREENCMULTIPLIER`)

--- a/RandomizerCore/Resources/default.logic
+++ b/RandomizerCore/Resources/default.logic
@@ -42,12 +42,13 @@
 #   Filler - Used to specify that this item should be used to fill any unfilled locations after all other items are placed. Items with the Filler type will be randomly chosen for each location left when randomization ends, and items can be chosen multiple times. Increase the number of a specific item in the Filler pool to increase the odds of that item being used.
 #
 # Items are built up in two different ways:
-#   In the item pool, they are - Items.(type).[subtype]:[amount]; (item pool type); [dungeon id]
-#    On unshuffled locations, they are - Items.(type).[subtype]
+#   In the item pool, they are - Items.(type).[subtype]:[amount].[multiplier]; (item pool type); [dungeon id]
+#   On unshuffled locations, they are - Items.(type).[subtype]
+# In the former case, if both an amount and a multiplier are given, the total number of added items is amount/multiplier rounded up.
 #
 # A location is built up as (name):[dungeon id 1]:[dungeon id 2]:...:[dungeon id N]; (location type); (address); [logic]; [item] (Only applies to Unshuffled locations)
 #
-# Give a location the dungeon_id: `NoSpoiler` to hide it from the spoiler log
+# Give a location the dungeon id: `NoSpoiler` to hide it from the spoiler log
 #
 # addresses can be written in multiple ways.
 # xx-xx-xx needs hexadecimal numbers to make an "area - room - chest id" combination
@@ -7957,7 +7958,7 @@ CoF_1F_Item2					`COF_INSIDE` 		`DUNGEONRUPEE`;	0x0DFAFB;																(|(&`EN
 CoF_1F_Item3					`COF_INSIDE` 		`DUNGEONRUPEE`;	0x0DFB0B;																(|(&`ENTERCOF`, Helpers.CoFRupees), Helpers.Hundo);																																									Items.Rupee1
 CoF_1F_Item4					`COF_INSIDE` 		`DUNGEONRUPEE`;	0x0DFB1B;																(|(&`ENTERCOF`, Helpers.CoFRupees), Helpers.Hundo);																																									Items.Rupee1
 CoF_1F_Item5					`COF_INSIDE`		`DUNGEONRUPEE`;	0x0DFB2B;																(|(&`ENTERCOF`, Helpers.CoFRupees), Helpers.Hundo);																																									Items.Rupee1
-			
+
 CoF_B1_HazyRoom_BigChest		`COF_INSIDE_COM`;	Dungeon;			0x50-0x09-0x01;															(|(&`ENTERCOF`, (|Helpers.BombWalls, Helpers.Bobombs), Helpers.CoFSpikeBeetle, Helpers.CoFHelmasaur), Helpers.Hundo);																										Items.Compass.0x19
 CoF_B1_HazyRoom_SmallChest		`COF_INSIDE`;		Dungeon;			0x50-0x09-0x00;															(|(&`ENTERCOF`, (|Helpers.BombWalls, Helpers.Bobombs), Helpers.CoFSpikeBeetle, Helpers.CoFHelmasaur), Helpers.Hundo);																										Items.Kinstone.BlueL
 CoF_B1_Rollobite_Chest			`COF_INSIDE`;		Dungeon;			0x50-0x08-0x01;															(|(&`ENTERCOF`, (|Helpers.BombWalls, Helpers.Bobombs), Helpers.CoFSpikeBeetle, Helpers.CoFHelmasaur, (|Helpers.HasSword, Items.GustJar, Items.PacciCane, Helpers.HasBoomerang, Items.BombBag)), Helpers.Hundo);						Items.Rupee50
@@ -7994,10 +7995,10 @@ Fortress_Left_2F_Item7					`FOW_INSIDE`		`FORTRESSRUPEE`;		0x0F3F97;												
 Fortress_Left_3F_SwitchChest			`FOW_INSIDE`;		`FORTRESSCHEST`;		0x18-0x02-0x00;														(|(&`ENTERFOW`, Helpers.FoWEyeSwitch, Helpers.FoWStalfosFight, Helpers.FoWDigSwitch), Helpers.Hundo);																					Items.Kinstone.RedV
 Fortress_Left_3F_Eyegore_BigChest		`FOW_INSIDE_MAP`;	`FORTRESSCHEST`;		0x58-0x00-0x00;														(|(&`ENTERFOW`, Helpers.FoWEyeSwitch, Helpers.FoWStalfosFight, Helpers.FoWCloneSwitch), Helpers.Hundo);																					Items.DungeonMap.0x1A
 Fortress_Left_3F_ItemDrop				`FOW_INSIDE_SK`;	`FORTRESSCHEST`;		fowLeftItem:Define:FirstByte,fowLeftSub:Define:SecondByte;					(|(&`ENTERFOW`, Helpers.FoWLeftDrop), Helpers.Hundo);																																Items.SmallKey.0x1A
-					
+
 Fortress_Middle_2F_BigChest			`FOW_INSIDE_COM`;	`FORTRESSCHEST`;		0x58-0x19-0x00;														(|(&`ENTERFOW`, (|Helpers.FoWEyegores, (&Helpers.FoWBlueWarp, Helpers.FoWDarknut))), Helpers.Hundo);																					Items.Compass.0x1A
 Fortress_Middle_2F_StatueChest			`FOW_INSIDE`;		`FORTRESSCHEST`;		0x18-0x01-0x01;														(|(&`ENTERFOW`, Items.MoleMitts), Helpers.Hundo);																																	Items.Kinstone.BlueL
-					
+
 Fortress_Right_2F_LeftChest			`FOW_INSIDE`;		`FORTRESSCHEST`;		0x58-0x1D-0x00;														(|`ENTERFOW`, Helpers.Hundo);																																					Items.Kinstone.BlueL
 Fortress_Right_2F_RightChest			`FOW_INSIDE`;		`FORTRESSCHEST`;		0x58-0x1D-0x01;														(|`ENTERFOW`, Helpers.Hundo);																																					Items.Kinstone.BlueS
 Fortress_Right_2F_DigChest				`FOW_INSIDE`;		`FORTRESSCHEST`;		0x18-0x01-0x02;														(|(&`ENTERFOW`, Items.MoleMitts), Helpers.Hundo);																																	Items.Kinstone.RedE
@@ -8013,7 +8014,7 @@ Fortress_BackRight_Minish_ItemDrop		`FOW_INSIDE_SK`;	`FORTRESSCHEST`;		0x0F424F;
 Fortress_BackRight_DigRoom_TopPot		`FOW_INSIDE`;		`FORTRESSPOT`;		0x0F3FC7:FirstByte, 0x0F3FC9:SecondByte;									(|(&`ENTERFOW`, (|(&Helpers.FoWBlueWarp, Helpers.FoWDarknut), Helpers.FoWEyegores), Helpers.FoWRightDoor, Helpers.FoWMiddleDoor, Items.MoleMitts), Helpers.Hundo);							Items.Rupee50
 Fortress_BackRight_DigRoom_BottomPot	`FOW_INSIDE`;		`FORTRESSPOT`;		0x0F3FD7:FirstByte, 0x0F3FD9:SecondByte;									(|(&`ENTERFOW`, (|(&Helpers.FoWBlueWarp, Helpers.FoWDarknut), Helpers.FoWEyegores), Helpers.FoWRightDoor, Helpers.FoWMiddleDoor, Items.MoleMitts), (&`ENTERFOW`, Helpers.FoWPot), Helpers.Hundo);	Items.Shells
 Fortress_BackRight_BigChest			`FOW_INSIDE_BK`;	`FORTRESSCHEST`;		0x58-0x1B-0x00;														(|(&`ENTERFOW`, (|(&Helpers.FoWBlueWarp, Helpers.FoWDarknut), Helpers.FoWEyegores), Helpers.FoWRightDoor, Helpers.FoWMiddleDoor, Items.MoleMitts, Helpers.FoWLastDoor), Helpers.Hundo);			Items.BigKey.0x1A
-	
+
 CompleteFortress;										Helper;				;																	`ENTERFOW`, Items.MoleMitts, Helpers.FoWBossDoor, Helpers.HasMazaalDamage, Helpers.HasBow;
 
 Fortress_BossItem						`FOW_INSIDE`;		`FORTRESSHP`;			mazaalContainerItem:Define:FirstByte, mazaalContainerSub:Define:SecondByte;	(|Helpers.CompleteFortress, Helpers.Hundo);																																		Items.HeartContainer


### PR DESCRIPTION
This allows the use of a multiplier when adding some number of items to the item pool. The multiplier value tells the parser how much "worth" the item is and makes the parser only add as many items as necessary to reach the requested total amount with the multiplier taken into account. The formula is just ceil(amount/multiplier).
The logic file uses this to only add the necessary amount of Kinstones to the pool when using Kinstone packs. Previously we had to manually check for each possible value and decide how many Kinstones to add to the pool separately for each case, which is why only the cases of pack sizes 1 and max were handled appropriately, the other options put way more Kinstones than needed in the pool.