### PR TITLE
Fix Biggoron interaction when it is set to not give an item

### DIFF
--- a/RandomizerCore/Resources/Patches/logicfixes/installer.event
+++ b/RandomizerCore/Resources/Patches/logicfixes/installer.event
@@ -184,7 +184,7 @@ PUSH; ORG $9400; SHORT 0x0400; SHORT 0x0400 //biggoron does not check for game c
 #ifdef enableBiggoronItem
 	SHORT 0x0803 //always jump (go to shield checks)
 #else
-	SHORT 0x0400 //never jump (go to major feat text)
+	SHORT 0x0400; SHORT 0x0400 //never jump (go to major feat text)
 #endif
 POP
 PUSH; ORG $9438; SHORT 0x0024; POP //use local flag 0xAC to determine whether the item was already received, if so, jump to thanks text


### PR DESCRIPTION
Instead of showing the intended textbox, talking to Biggoron froze the game when it was set to not give an item.