### PR TITLE
Fix an issue with setting strings

### DIFF
--- a/MinishCapRandomizerCLI/GenericCommands.cs
+++ b/MinishCapRandomizerCLI/GenericCommands.cs
@@ -508,9 +508,9 @@ internal static class GenericCommands
     {
         switch (option)
         {
-            case LogicFlag:
+            case LogicFlag flag:
             {
-                return option.Active.ToString();
+                return flag.Active.ToString();
             }
             case LogicDropdown dropdown:
             {
@@ -522,7 +522,7 @@ internal static class GenericCommands
             }
             case LogicNumberBox box:
             {
-                return box.Value;
+                return $"{box.Value}";
             }
         }
         return "";
@@ -532,7 +532,7 @@ internal static class GenericCommands
     {
         switch (option)
         {
-            case LogicFlag:
+            case LogicFlag flag:
             {
                 Console.WriteLine("1) Enabled");
                 Console.WriteLine("2) Disabled");
@@ -547,7 +547,7 @@ internal static class GenericCommands
                     break;
                 }
 
-                option.Active = i == 1;
+                flag.Active = i == 1;
                 Console.WriteLine("Flag set successfully!");
                 break;
             }
@@ -645,14 +645,14 @@ internal static class GenericCommands
                 var input = Console.ReadLine();
                 if (string.IsNullOrEmpty(input) || !int.TryParse(input, out var i) || i < box.MinValue || i > box.MaxValue)
                 {
-                    if (!input!.Equals("exit", StringComparison.OrdinalIgnoreCase))
+                    if (input != null && !input.Equals("exit", StringComparison.OrdinalIgnoreCase))
                     {
                         PrintError("Invalid Input!");
                     }
                     break;
                 }
 
-                box.Value = input;
+                box.Value = (byte)i;
                 Console.WriteLine("Number box value set successfully!");
                 break;
             }

--- a/MinishCapRandomizerUI/Elements/NumberBoxWrapper.cs
+++ b/MinishCapRandomizerUI/Elements/NumberBoxWrapper.cs
@@ -47,7 +47,7 @@ public class NumberBoxWrapper : WrapperBase, ILogicOptionObserver
         {
             AutoSize = false,
             Name = _numberBox.Name,
-            Text = _numberBox.Value,
+            Text = _numberBox.Value.ToString(),
             Minimum = _numberBox.MinValue,
             Maximum = _numberBox.MaxValue,
             Location = new Point(initialX + (int)((TextWidth + Constants.WidthMargin)*Constants.SpecialScaling), initialY + NumberBoxAlign),
@@ -71,24 +71,31 @@ public class NumberBoxWrapper : WrapperBase, ILogicOptionObserver
         {
             if (_upDownBox.Text.Length == 0)
             {
-                _numberBox.Value = _upDownBox.Text = _numberBox.DefaultValue.ToString();
+                _numberBox.Value = _numberBox.DefaultValue;
+                _upDownBox.Text = _numberBox.DefaultValue.ToString();
                 return;
             }
 
             if (byte.TryParse(_upDownBox.Text, out var val))
             {
                 if (val > _numberBox.MaxValue)
-                    _numberBox.Value = _upDownBox.Text = _numberBox.MaxValue.ToString();
+                { 
+                    _numberBox.Value = _numberBox.MaxValue;
+                    _upDownBox.Text = _numberBox.MaxValue.ToString();
+                }
                 else
                 {
                     if (val < _numberBox.MinValue)
-                        _numberBox.Value = _upDownBox.Text = _numberBox.MinValue.ToString();
+                    { 
+                        _numberBox.Value = _numberBox.MinValue;
+                        _upDownBox.Text = _numberBox.MinValue.ToString();
+                    }
                     else
-                        _numberBox.Value = val.ToString();
+                        _numberBox.Value = val;
                 }
             }
             else
-                _upDownBox.Text = _numberBox.Value;
+                _upDownBox.Text = _numberBox.Value.ToString();
         };
 
         return new List<Control> { _label, _upDownBox };

--- a/RandomizerCore/Controllers/ControllerBase.cs
+++ b/RandomizerCore/Controllers/ControllerBase.cs
@@ -516,17 +516,17 @@ public abstract class ControllerBase
         }
     }
 
-    private void LoadSettings(bool loadLogicSettings, bool loadCosmeticSettings, IEnumerable<LogicOptionBase> options, YAMLResult result)
+    private static void LoadSettings(bool loadLogicSettings, bool loadCosmeticSettings, IEnumerable<LogicOptionBase> options, YAMLResult result)
     {
         var resultOptionsIndex = 0;
 
         foreach (var option in options)
         {
             if (option.Type == LogicOptionType.Setting ? !loadLogicSettings : !loadCosmeticSettings) continue;
-            
+
             if (option.Name != result.Options[resultOptionsIndex].Name)
                 throw new Exception($"Attempt to load options from yaml failed! Expected {result.Options[resultOptionsIndex].Name}, got {option.Name}");
-                        
+
             option.CopyValueFrom(result.Options[resultOptionsIndex++]);
             option.NotifyObservers();
         }

--- a/RandomizerCore/Randomizer/Helpers/OptionList.cs
+++ b/RandomizerCore/Randomizer/Helpers/OptionList.cs
@@ -32,11 +32,7 @@ public class OptionList : List<LogicOptionBase>
 
     public byte[] GetBytes()
     {
-        var bytes = new byte[Count];
-
-        for (var i = 0; i < Count; i++) bytes[i] = this[i].GetHashByte();
-
-        return bytes;
+        return this.Select(option => option.GetSelectionHashByte()).ToArray();
     }
 
     public uint GetCrc32()

--- a/RandomizerCore/Randomizer/Helpers/OptionList.cs
+++ b/RandomizerCore/Randomizer/Helpers/OptionList.cs
@@ -44,6 +44,7 @@ public class OptionList : List<LogicOptionBase>
             bytes.AddRange(Encoding.UTF8.GetBytes(option.Name));
             bytes.AddRange(Encoding.UTF8.GetBytes(option.Type.ToString()));
             bytes.AddRange(Encoding.UTF8.GetBytes(option.GetType().ToString()));
+            bytes.AddRange(option.GetAdditionalHashBytes());
         }
 
         return bytes.ToArray().Crc32();

--- a/RandomizerCore/Randomizer/Logic/Options/LogicColorPicker.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicColorPicker.cs
@@ -17,14 +17,12 @@ public class LogicColorPicker : LogicOptionBase
         string descriptionText,
         LogicOptionType type,
         Color startingColor) :
-        base(name, niceName, true, settingGroup, settingPage, descriptionText, type)
+        base(name, niceName, settingGroup, settingPage, descriptionText, type)
     {
+        Active = true;
         BaseColor = startingColor;
         DefinedColor = startingColor;
-        InitialColors = new List<Color>(1)
-        {
-            startingColor
-        };
+        InitialColors = [startingColor];
         UseRandomColor = false;
     }
 
@@ -36,8 +34,9 @@ public class LogicColorPicker : LogicOptionBase
         string descriptionText,
         LogicOptionType type,
         List<Color> colors) :
-        base(name, niceName, true, settingGroup, settingPage, descriptionText, type)
+        base(name, niceName, settingGroup, settingPage, descriptionText, type)
     {
+        Active = true;
         BaseColor = colors[0];
         DefinedColor = colors[0];
         InitialColors = colors;
@@ -53,8 +52,8 @@ public class LogicColorPicker : LogicOptionBase
 
     public override void CopyValueFrom(LogicOptionBase option)
     {
-        base.CopyValueFrom(option);
         var colorPicker = (LogicColorPicker)option;
+        Active = colorPicker.Active;
         UseRandomColor = colorPicker.UseRandomColor;
         DefinedColor = colorPicker.DefinedColor;
     }
@@ -63,6 +62,7 @@ public class LogicColorPicker : LogicOptionBase
     public Color DefinedColor { get; set; }
     public List<Color> InitialColors { get; set; }
 
+    public bool Active { get; set; }
     public bool UseRandomColor { get; set; }
 
     public void PickRandomColor()
@@ -95,7 +95,7 @@ public class LogicColorPicker : LogicOptionBase
         return defineList;
     }
 
-    public override byte GetHashByte()
+    public override byte GetSelectionHashByte()
     {
         // Maybe not a great way to represent, leaves some info out and is likely to cause easy collisions
         return Active ? (byte)(DefinedColor.R ^ DefinedColor.G ^ DefinedColor.B) : (byte)00;

--- a/RandomizerCore/Randomizer/Logic/Options/LogicDropdown.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicDropdown.cs
@@ -17,7 +17,7 @@ public class LogicDropdown : LogicOptionBase
         string defaultSelection,
         LogicOptionType type,
         Dictionary<string, string> selections) :
-        base(name, niceName, true, settingGroup, settingPage, descriptionText, type)
+        base(name, niceName, settingGroup, settingPage, descriptionText, type)
     {
         Selections = selections;
         DefaultSelection = defaultSelection;
@@ -33,33 +33,26 @@ public class LogicDropdown : LogicOptionBase
 
     public override void CopyValueFrom(LogicOptionBase option)
     {
-        base.CopyValueFrom(option);
-        Selection = ((LogicDropdown)option).Selection;
+        var dropdown = (LogicDropdown)option;
+        if (!Selections.ContainsKey(dropdown.Selection))
+            throw new Exception($"Attempt to load option {Name} failed! Invalid value {dropdown.Selection}");
+        Selection = dropdown.Selection;
     }
 
-    public string Selection { get; set; }
-    public string DefaultSelection { get; }
+    // TODO: This could use some refactoring. The dictionary is not guaranteed to keep the intended order of the options, and it is not intuitive which side represents what.
+    public string Selection { get; set; } // must be a key
+    public string DefaultSelection { get; } // must be a value
     public Dictionary<string, string> Selections { get; }
 
     public override List<LogicDefine> GetLogicDefines()
     {
-        var defineList = new List<LogicDefine>(3);
-
-        // Only true if a color has been selected
-        if (!Active) return defineList;
-
-
-        if (!Selections.TryGetValue(Selection, out var content)) return defineList;
-
         Logger.Instance.LogInfo($"Active Define: {NiceName}, Value: {Selection}");
-        defineList.Add(new LogicDefine(Name, content));
-
-        return defineList;
+        return [new LogicDefine(Name, Selections[Selection])];
     }
 
-    public override byte GetHashByte()
+    public override byte GetSelectionHashByte()
     {
-        return Active ? Encoding.ASCII.GetBytes(Selection).Crc8() : (byte)0x0b;
+        return Encoding.ASCII.GetBytes(Selection).Crc8();
     }
 
     public override string GetOptions()

--- a/RandomizerCore/Randomizer/Logic/Options/LogicDropdown.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicDropdown.cs
@@ -50,6 +50,13 @@ public class LogicDropdown : LogicOptionBase
         return [new LogicDefine(Name, Selections[Selection])];
     }
 
+    public override IEnumerable<byte> GetAdditionalHashBytes()
+    {
+        List<byte> b = [(byte)Selections.Count];
+        b.AddRange(Selections.SelectMany(option => Encoding.UTF8.GetBytes(option.Value)));
+        return b;
+    }
+
     public override byte GetSelectionHashByte()
     {
         return Encoding.ASCII.GetBytes(Selection).Crc8();

--- a/RandomizerCore/Randomizer/Logic/Options/LogicFlag.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicFlag.cs
@@ -5,6 +5,7 @@ namespace RandomizerCore.Randomizer.Logic.Options;
 
 public class LogicFlag : LogicOptionBase
 {
+    public bool Active { get; set; }
     public bool Default { get; }
 
     public LogicFlag(
@@ -15,14 +16,20 @@ public class LogicFlag : LogicOptionBase
         string settingPage,
         string descriptionText,
         LogicOptionType type) :
-        base(name, niceName, active, settingGroup, settingPage, descriptionText, type)
+        base(name, niceName, settingGroup, settingPage, descriptionText, type)
     {
+        Active = active;
         Default = active;
     }
 
     public override void Reset()
     {
         Active = Default;
+    }
+
+    public override void CopyValueFrom(LogicOptionBase option)
+    {
+        Active = ((LogicFlag)option).Active;
     }
 
     public override List<LogicDefine> GetLogicDefines()
@@ -35,7 +42,7 @@ public class LogicFlag : LogicOptionBase
         return defineList;
     }
 
-    public override byte GetHashByte()
+    public override byte GetSelectionHashByte()
     {
         return Active ? (byte)01 : (byte)00;
     }

--- a/RandomizerCore/Randomizer/Logic/Options/LogicNumberBox.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicNumberBox.cs
@@ -16,56 +16,46 @@ public class LogicNumberBox : LogicOptionBase
         byte maximumValue,
         string descriptionText,
         LogicOptionType type) :
-        base(name, niceName, true, settingGroup, settingPage, descriptionText, type)
+        base(name, niceName, settingGroup, settingPage, descriptionText, type)
     {
         MinValue = minimumValue;
         MaxValue = maximumValue;
         DefaultValue = defaultValue;
-        Value = $"{DefaultValue}";
+        Value = defaultValue;
     }
 
-    public string Value { get; set; }
+    public byte Value { get; set; }
     public byte MinValue { get; }
     public byte MaxValue { get; }
     public byte DefaultValue { get; }
 
     public override void Reset()
     {
-        Value = $"{DefaultValue}";
+        Value = DefaultValue;
     }
 
     public override void CopyValueFrom(LogicOptionBase option)
     {
-        base.CopyValueFrom(option);
-        Value = ((LogicNumberBox)option).Value;
+        LogicNumberBox numberBox = (LogicNumberBox)option;
+        if (numberBox.Value < MinValue || numberBox.Value > MaxValue)
+            throw new Exception($"Attempt to load option {Name} failed! Invalid value {numberBox.Value}");
+        Value = numberBox.Value;
     }
 
     public override List<LogicDefine> GetLogicDefines()
     {
-        var defineList = new List<LogicDefine>(3);
-
-        // Only true if valid text has been entered
-        if (Value != "")
-        {
-            Logger.Instance.LogInfo($"Number box name: {Name}, Value: {Value}");
-            defineList.Add(new LogicDefine(Name, Value));
-        }
-        else
-        {
-            defineList.Add(new LogicDefine(Name, "0"));
-        }
-
-        return defineList;
+        Logger.Instance.LogInfo($"Number box name: {Name}, Value: {Value}");
+        return [new LogicDefine(Name, $"{Value}")];
     }
 
-    public override byte GetHashByte()
+    public override byte GetSelectionHashByte()
     {
-        return Value != "" ? byte.Parse(Value) : (byte)0;
+        return Value;
     }
 
     public override string GetOptions()
     {
-        return "A number between 0 and 255";
+        return $"A number between {MinValue} and {MaxValue}";
     }
 
     public override string GetOptionUiType()

--- a/RandomizerCore/Randomizer/Logic/Options/LogicNumberBox.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicNumberBox.cs
@@ -48,6 +48,11 @@ public class LogicNumberBox : LogicOptionBase
         return [new LogicDefine(Name, $"{Value}")];
     }
 
+    public override IEnumerable<byte> GetAdditionalHashBytes()
+    {
+        return [MinValue, MaxValue];
+    }
+
     public override byte GetSelectionHashByte()
     {
         return Value;

--- a/RandomizerCore/Randomizer/Logic/Options/LogicOptionBase.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicOptionBase.cs
@@ -11,15 +11,13 @@ public abstract class LogicOptionBase : ICloneable
     protected LogicOptionBase(
         string name,
         string niceName,
-        bool active,
         string settingGroup,
         string settingPage,
         string descriptionText,
-        LogicOptionType type = LogicOptionType.Untyped)
+        LogicOptionType type)
     {
         Name = name;
         NiceName = niceName;
-        Active = active;
         Type = type;
         SettingGroup = settingGroup;
         SettingPage = settingPage;
@@ -27,16 +25,15 @@ public abstract class LogicOptionBase : ICloneable
         var builder = new StringBuilder();
         foreach (var s in tempText.Split("\\n")) builder.AppendLine(s);
         DescriptionText = builder.ToString();
-        Observers = new List<ILogicOptionObserver>();
+        Observers = [];
     }
 
-    public string Name { get; set; }
-    public string NiceName { get; set; }
-    public bool Active { get; set; }
-    public LogicOptionType Type { get; set; }
-    public string SettingGroup { get; set; }
-    public string SettingPage { get; set; }
-    public string DescriptionText { get; set; }
+    public string Name { get; }
+    public string NiceName { get; }
+    public LogicOptionType Type { get; }
+    public string SettingGroup { get; }
+    public string SettingPage { get; }
+    public string DescriptionText { get; }
 
     public void NotifyObservers()
     {
@@ -50,16 +47,13 @@ public abstract class LogicOptionBase : ICloneable
 
     public abstract void Reset();
 
-    public virtual void CopyValueFrom(LogicOptionBase option)
-    {
-        Active = option.Active;
-    }
+    public abstract void CopyValueFrom(LogicOptionBase option);
 
     public abstract List<LogicDefine> GetLogicDefines();
 
     public abstract string GetOptions();
 
-    public abstract byte GetHashByte();
+    public abstract byte GetSelectionHashByte();
 
     public abstract string GetOptionUiType();
 

--- a/RandomizerCore/Randomizer/Logic/Options/LogicOptionBase.cs
+++ b/RandomizerCore/Randomizer/Logic/Options/LogicOptionBase.cs
@@ -53,6 +53,11 @@ public abstract class LogicOptionBase : ICloneable
 
     public abstract string GetOptions();
 
+    public virtual IEnumerable<byte> GetAdditionalHashBytes()
+    {
+        return [];
+    }
+
     public abstract byte GetSelectionHashByte();
 
     public abstract string GetOptionUiType();

--- a/RandomizerCore/Randomizer/Parser/DirectiveParser.cs
+++ b/RandomizerCore/Randomizer/Parser/DirectiveParser.cs
@@ -321,7 +321,7 @@ public class DirectiveParser
         var settings = Options.Where(option => option.Type == LogicOptionType.Setting).ToList();
         var bytes = new byte[settings.Count];
 
-        for (var i = 0; i < settings.Count; i++) bytes[i] = settings[i].GetHashByte();
+        for (var i = 0; i < settings.Count; i++) bytes[i] = settings[i].GetSelectionHashByte();
 
         return bytes;
     }
@@ -331,7 +331,7 @@ public class DirectiveParser
         var cosmetics = Options.Where(option => option.Type == LogicOptionType.Cosmetic).ToList();
         var bytes = new byte[cosmetics.Count];
 
-        for (var i = 0; i < cosmetics.Count; i++) bytes[i] = cosmetics[i].GetHashByte();
+        for (var i = 0; i < cosmetics.Count; i++) bytes[i] = cosmetics[i].GetSelectionHashByte();
 
         return bytes;
     }
@@ -605,11 +605,9 @@ public class DirectiveParser
     {
         if (directiveParts.Length != 3) throw new ParserException("!settype has an invalid amount of arguments");
 
-        LocationType newType;
-
         var replacedItem = new Item(directiveParts[1], "!settype");
 
-        if (!Enum.TryParse(directiveParts[2], out newType))
+        if (!Enum.TryParse(directiveParts[2], out LocationType newType))
             throw new ParserException("!settype has an invalid replaced location type");
 
         LocationTypeOverrides.Add(replacedItem, newType);
@@ -618,12 +616,12 @@ public class DirectiveParser
     private LogicFlag ParseFlagDirective(string[] directiveParts)
     {
         if (directiveParts.Length < 7)
-            throw new ParserException("A flag somewhere has an incorrect number of parameters!");
+            throw new ParserException("Flag has an incorrect number of parameters!");
 
         var optionType = GetOptionType(directiveParts[2]);
 
         if (optionType == LogicOptionType.Untyped)
-            throw new ParserException($"A flag somewhere has an invalid type! ({directiveParts[2]})");
+            throw new ParserException($"Flag has an invalid type! ({directiveParts[2]})");
 
         bool defaultActive;
         if (directiveParts.Length > 7)
@@ -640,15 +638,15 @@ public class DirectiveParser
             directiveParts[3], directiveParts[1], directiveParts[6], optionType);
     }
 
-    private LogicOptionBase ParseDropdownDirective(string[] directiveParts)
+    private LogicDropdown ParseDropdownDirective(string[] directiveParts)
     {
         if (directiveParts.Length % 3 != 2 || directiveParts.Length < 11)
-            throw new ParserException("A dropdown somewhere has an incorrect number of parameters!");
+            throw new ParserException("Dropdown has an incorrect number of parameters!");
 
         var optionType = GetOptionType(directiveParts[2]);
 
         if (optionType == LogicOptionType.Untyped)
-            throw new ParserException($"A dropdown somewhere has an invalid type! ({directiveParts[2]})");
+            throw new ParserException($"Dropdown has an invalid type! ({directiveParts[2]})");
 
         var selectionDict = new Dictionary<string, string>();
         var descriptionText = new StringBuilder();
@@ -660,6 +658,15 @@ public class DirectiveParser
             selectionDict.Add(directiveParts[i++], directiveParts[i++]);
             descriptionText.AppendLine($"\n{directiveParts[i++]}");
         }
+
+        if (selectionDict.Keys.Count != (directiveParts.Length - 8) / 3)
+            throw new ParserException("Dropdown has multiple options with the same readable name!");
+
+        if (selectionDict.Values.Count != (directiveParts.Length - 8) / 3)
+            throw new ParserException("Dropdown has multiple options with the same define name!");
+
+        if (!selectionDict.ContainsValue(defaultSelection))
+            throw new ParserException($"Dropdown has an invalid default value {defaultSelection}!");
 
         return new LogicDropdown(directiveParts[4], directiveParts[5], directiveParts[3],
             directiveParts[1], descriptionText.ToString(), defaultSelection, optionType, selectionDict);
@@ -698,7 +705,7 @@ public class DirectiveParser
             "Colorpicker does not have the right number of parameters!");
     }
 
-    private LogicOptionBase ParseNumberboxDirective(string[] directiveParts)
+    private LogicNumberBox ParseNumberboxDirective(string[] directiveParts)
     {
         if (directiveParts.Length != 10)
             throw new ParserException("Numberbox does not have the right number of parameters!");
@@ -718,7 +725,7 @@ public class DirectiveParser
             throw new ParserException($"Numberbox has invalid maximum value {directiveParts[9]}!");
 
         if (minValue > defaultValue || maxValue < defaultValue)
-            throw new ParserException("Numberbox has default value outside allowed range!");
+            throw new ParserException($"Numberbox has default value {defaultValue} outside allowed range {minValue}-{maxValue}!");
 
         return new LogicNumberBox(directiveParts[4], directiveParts[5], directiveParts[3],
             directiveParts[1], defaultValue, minValue, maxValue, directiveParts[6], optionType);

--- a/RandomizerCore/Utilities/Models/MinifiedSettings.cs
+++ b/RandomizerCore/Utilities/Models/MinifiedSettings.cs
@@ -87,7 +87,7 @@ internal static class MinifiedSettings
 
             var numberBox = numberBoxes[numberBoxesProcessed];
 
-            numberBox.Value = $"{currentByte}";
+            numberBox.Value = currentByte;
             numberBox.NotifyObservers();
         }
 
@@ -168,7 +168,7 @@ internal static class MinifiedSettings
 
         for (var numberBoxesProcessed = 0; numberBoxesProcessed < numberBoxes.Count; ++numberBoxesProcessed)
         {
-            currentByte = numberBoxes[numberBoxesProcessed].GetHashByte();
+            currentByte = numberBoxes[numberBoxesProcessed].Value;
             bytes.Add(currentByte);
         }
 

--- a/RandomizerCore/Utilities/Models/MinifiedSettings.cs
+++ b/RandomizerCore/Utilities/Models/MinifiedSettings.cs
@@ -37,7 +37,7 @@ internal static class MinifiedSettings
             ? optionGroups.First(group => group.Key == typeof(LogicFlag)).Cast<LogicFlag>().ToList()
             : new List<LogicFlag>();
 
-        for (int i = 7, flagsProcressed = 0; flagsProcressed < flags.Count; --i, ++flagsProcressed)
+        for (int i = 7, flagsProcessed = 0; flagsProcessed < flags.Count; --i, ++flagsProcessed)
         {
             if (i < 0)
             {
@@ -47,8 +47,8 @@ internal static class MinifiedSettings
 
             var flagBit = (currentByte >> i) & 1;
 
-            flags[flagsProcressed].Active = flagBit == 1;
-            flags[flagsProcressed].NotifyObservers();
+            flags[flagsProcessed].Active = flagBit == 1;
+            flags[flagsProcessed].NotifyObservers();
         }
 
         currentByte = bytes[++currentIndex];
@@ -77,17 +77,32 @@ internal static class MinifiedSettings
             dropdown.NotifyObservers();
         }
 
+        currentByte = bytes[++currentIndex];
+
         var numberBoxes = optionGroups.Any(group => group.Key == typeof(LogicNumberBox))
             ? optionGroups.First(group => group.Key == typeof(LogicNumberBox)).Cast<LogicNumberBox>().ToList()
             : new List<LogicNumberBox>();
 
-        for (var numberBoxesProcessed = 0; numberBoxesProcessed < numberBoxes.Count; ++numberBoxesProcessed)
+        for (int i = 8, numberBoxesProcessed = 0; numberBoxesProcessed < numberBoxes.Count; ++numberBoxesProcessed)
         {
-            currentByte = bytes[++currentIndex];
-
             var numberBox = numberBoxes[numberBoxesProcessed];
+            var (mask, bitCount) = GetBitInfoForOptionCount(numberBox.MaxValue + 1 - numberBox.MinValue);
+            var numberBoxIndex = 0;
+            i -= bitCount;
 
-            numberBox.Value = currentByte;
+            if (i < 0)
+            {
+                i += 8;
+                numberBoxIndex |= (currentByte << (8 - i)) & mask;
+                currentByte = bytes[++currentIndex];
+            }
+
+            numberBoxIndex |= (currentByte >> i) & mask;
+
+            var value = numberBoxIndex + numberBox.MinValue;
+            if (value > numberBox.MaxValue)
+                throw new InvalidSettingStringException("Minified settings string is invalid because a NumberBox value is out of range!");
+            numberBox.Value = (byte)value;
             numberBox.NotifyObservers();
         }
 
@@ -122,7 +137,7 @@ internal static class MinifiedSettings
             : new List<LogicFlag>();
         byte currentByte = 0;
 
-        for (int i = 7, flagsProcressed = 0; flagsProcressed < flags.Count; --i, ++flagsProcressed)
+        for (int i = 7, flagsProcessed = 0; flagsProcessed < flags.Count; --i, ++flagsProcessed)
         {
             if (i < 0)
             {
@@ -131,7 +146,7 @@ internal static class MinifiedSettings
                 currentByte = 0;
             }
 
-            currentByte |= flags[flagsProcressed].Active ? (byte)(1 << i) : (byte)(0 << i);
+            currentByte |= flags[flagsProcessed].Active ? (byte)(1 << i) : (byte)0;
         }
 
         bytes.Add(currentByte);
@@ -153,24 +168,38 @@ internal static class MinifiedSettings
                 i += 8;
                 currentByte |= (byte)(dropdownValueAsByte >> (8 - i));
                 bytes.Add(currentByte);
-                currentByte = 0;
-                currentByte |= (byte)(dropdownValueAsByte << i);
+                currentByte = (byte)(dropdownValueAsByte << i);
             }
 
             currentByte |= (byte)(dropdownValueAsByte << i);
         }
 
         bytes.Add(currentByte);
+        currentByte = 0;
 
         var numberBoxes = optionGroups.Any(group => group.Key == typeof(LogicNumberBox))
             ? optionGroups.First(group => group.Key == typeof(LogicNumberBox)).Cast<LogicNumberBox>().ToList()
             : new List<LogicNumberBox>();
 
-        for (var numberBoxesProcessed = 0; numberBoxesProcessed < numberBoxes.Count; ++numberBoxesProcessed)
+        for (int i = 8, numberBoxesProcessed = 0; numberBoxesProcessed < numberBoxes.Count; ++numberBoxesProcessed)
         {
-            currentByte = numberBoxes[numberBoxesProcessed].Value;
-            bytes.Add(currentByte);
+            var numberBox = numberBoxes[numberBoxesProcessed];
+            var (mask, bitCount) = GetBitInfoForOptionCount(numberBox.MaxValue + 1 - numberBox.MinValue);
+            var numberBoxValueAsByte = (numberBox.Value - numberBox.MinValue) & mask;
+            i -= bitCount;
+
+            if (i < 0)
+            {
+                i += 8;
+                currentByte |= (byte)(numberBoxValueAsByte >> (8 - i));
+                bytes.Add(currentByte);
+                currentByte = (byte)(numberBoxValueAsByte << i);
+            }
+
+            currentByte |= (byte)(numberBoxValueAsByte << i);
         }
+
+        bytes.Add(currentByte);
 
         var colorPickers = optionGroups.Any(group => group.Key == typeof(LogicColorPicker))
             ? optionGroups.First(group => group.Key == typeof(LogicColorPicker)).Cast<LogicColorPicker>().ToList()

--- a/RandomizerCore/Utilities/Util/YamlParser.cs
+++ b/RandomizerCore/Utilities/Util/YamlParser.cs
@@ -31,7 +31,7 @@ internal static class YamlParser
                 {
                     switch (option)
                     {
-                        case LogicFlag:
+                        case LogicFlag flag:
                             if (mysteryFlag)
                             {
                                 content += PadComment(indent + option.Name + ":", option.NiceName, commentOffset);
@@ -39,7 +39,7 @@ internal static class YamlParser
                                 content += indent + indent + "off: 1" + Environment.NewLine;
                             }
                             else
-                                content += PadComment(indent + option.Name + ": " + (option.Active ? "on" : "off"), option.NiceName, commentOffset);
+                                content += PadComment(indent + option.Name + ": " + (flag.Active ? "on" : "off"), option.NiceName, commentOffset);
                             break;
                         case LogicDropdown dropdown:
                             if (mysteryFlag)
@@ -197,14 +197,14 @@ internal static class YamlParser
     {
         switch (option)
         {
-            case LogicFlag:
+            case LogicFlag flag:
                 if (string.Equals(value, "on", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || value == "1")
-                    option.Active = true;
+                    flag.Active = true;
                 else
                 {
                     if (string.Equals(value, "off", StringComparison.OrdinalIgnoreCase) ||
                         string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) || value == "0")
-                        option.Active = false;
+                        flag.Active = false;
                     else
                         throw new ParserException($"Invalid value \"{value}\" for Flag option \"{option.Name}\"");
                 }
@@ -266,7 +266,7 @@ internal static class YamlParser
                 break;
             case LogicNumberBox box:
                 if (int.TryParse(value, out var i) && i >= box.MinValue && i <= box.MaxValue)
-                    box.Value = i.ToString();
+                    box.Value = (byte)i;
                 else
                 {
                     var split = value.Split(" ");
@@ -278,7 +278,7 @@ internal static class YamlParser
                         if (step <= 0)
                             throw new ParserException($"Invalid value \"{value}\" for Number option \"{option.Name}\"");
                         var val = min + random.Next((max - min) / step + 1) * step;
-                        box.Value = val.ToString();
+                        box.Value = (byte)val;
                     }
                     else
                         throw new ParserException($"Invalid value \"{value}\" for Number option \"{option.Name}\"");


### PR DESCRIPTION
Ceratin types of changes to dropdown or numberbox settings did not change the settings hash, making the setting string appear like it's compatible when it isn't.
Also contains an optimization to save space with numberbox settings, in the same way as in https://github.com/minishmaker/randomizer/pull/87 for dropdowns.